### PR TITLE
feat: add audit page

### DIFF
--- a/static/audit.html
+++ b/static/audit.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Audit report</title>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-KK94CHFLLe+nY2dmCWGMq91rCGa5gtU4mk92HdvYe+M/SXH301p5ILy+dN9+nJOZ" crossorigin="anonymous">
+    </head>
+    <body>
+        <div class="container">
+            <h1>Audit report</h1>
+            <!-- params -->
+            <div class="mb-3">
+                <label for="etherscanApiKey" class="form-label">Etherscan API key</label>
+                <input type="text" class="form-control" id="etherscanApiKey">
+            </div>
+            <div class="mb-3">
+                <label for="rpcUrl" class="form-label">RPC URL</label>
+                <input type="text" class="form-control" id="rpcUrl">
+            </div>
+            <div class="mb-3">
+                <label for="botWalletAddress" class="form-label">Bot wallet address</label>
+                <input type="text" class="form-control" id="botWalletAddress">
+            </div>
+            <div class="mb-3">
+                <label for="githubPat" class="form-label">Github personal access token (with "repo" scope)</label>
+                <input type="text" class="form-control" id="githubPat">
+            </div>
+            <div class="mb-3">
+                <label for="ownerName" class="form-label">Owner name</label>
+                <input type="text" class="form-control" id="ownerName">
+            </div>
+            <div class="mb-3">
+                <label for="repoName" class="form-label">Repository name</label>
+                <input type="text" class="form-control" id="repoName">
+            </div>
+            <button type="button" class="btn btn-primary mb-3" id="getReport">Get report</button>
+            <!-- loader -->
+            <div id="loader" class="mb-3" style="display: none;">
+                Loading...
+                <p id="log"></p>
+            </div>
+            <!-- result table -->
+            <table id="resultTable" class="table" style="display: none;">
+                <thead>
+                  <tr>
+                    <th scope="col">Issue URL</th>
+                    <th scope="col">Transaction URL</th>
+                    <th scope="col">Amount (DAI)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                    <!-- table content -->
+                </tbody>
+            </table>
+        </div>
+
+        <script src="https://cdn.ethers.io/lib/ethers-5.2.umd.min.js" type="application/javascript"></script>
+
+        <script type="module">
+            import { Octokit } from "https://cdn.skypack.dev/octokit";
+
+            let ETHERSCAN_API_KEY = ''; // 5 requests per second
+            let RPC_URL = '';
+            let BOT_WALLET_ADDRESS = '';
+            let GITHUB_PERSONAL_ACCESS_TOKEN = ''; // PAT with "repo" scope
+            let OWNER_NAME = '';
+            let REPOSITORY_NAME = '';
+
+            /**
+             * On "get report" btn click 
+             */
+            document.getElementById('getReport').onclick = async () => {
+                // get constants from inputs
+                ETHERSCAN_API_KEY = document.getElementById('etherscanApiKey').value;
+                RPC_URL = document.getElementById('rpcUrl').value;
+                BOT_WALLET_ADDRESS = document.getElementById('botWalletAddress').value;
+                GITHUB_PERSONAL_ACCESS_TOKEN = document.getElementById('githubPat').value;
+                OWNER_NAME = document.getElementById('ownerName').value;
+                REPOSITORY_NAME = document.getElementById('repoName').value;
+                // hide result table
+                document.getElementById("resultTable").style.display = 'none';
+                // show loader
+                document.getElementById("loader").style.display = 'block';
+                // get table items
+                const tableItems = await getTableItems();
+                // insert table rows
+                let rowsHtml = '';
+                for (let tableItem of tableItems) {
+                    rowsHtml += `
+                        <tr>
+                            <td><a href="${tableItem.issueUrl}" target="_blank">${tableItem.issueUrl}</a></td>
+                            <td><a href="${tableItem.txUrl}" target="_blank">${tableItem.txUrl}</a></td>
+                            <td>${tableItem.amount}</td>
+                        </tr>
+                    `;
+                }
+                document.querySelector("#resultTable tbody").innerHTML = rowsHtml;
+                // hide loader
+                document.getElementById("loader").style.display = 'none';
+                // show result table
+                document.getElementById("resultTable").style.display = 'table';
+             };
+
+            // TODO: etherscan pagination
+            // TODO: handle errors
+            // TODO: retry on rate limit
+            // TODO: cache responses in local storage
+            async function getTableItems() {
+                let results = [];
+
+                try {
+                    // get all TXs for wallet address
+                    const walletTxsRaw = await fetch(`https://api.etherscan.io/api?module=account&action=tokentx&address=${BOT_WALLET_ADDRESS}&apikey=${ETHERSCAN_API_KEY}`);
+                    const walletTxs = (await walletTxsRaw.json()).result;
+
+                    // prepare RPC provider for getting TX data
+                    const provider = new ethers.providers.JsonRpcProvider(RPC_URL);
+                    // prepare permit2 ABI
+                    const permit2Abi = '[{"inputs":[{"internalType":"uint256","name":"deadline","type":"uint256"}],"name":"AllowanceExpired","type":"error"},{"inputs":[],"name":"ExcessiveInvalidation","type":"error"},{"inputs":[{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"InsufficientAllowance","type":"error"},{"inputs":[{"internalType":"uint256","name":"maxAmount","type":"uint256"}],"name":"InvalidAmount","type":"error"},{"inputs":[],"name":"InvalidContractSignature","type":"error"},{"inputs":[],"name":"InvalidNonce","type":"error"},{"inputs":[],"name":"InvalidSignature","type":"error"},{"inputs":[],"name":"InvalidSignatureLength","type":"error"},{"inputs":[],"name":"InvalidSigner","type":"error"},{"inputs":[],"name":"LengthMismatch","type":"error"},{"inputs":[{"internalType":"uint256","name":"signatureDeadline","type":"uint256"}],"name":"SignatureExpired","type":"error"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"owner","type":"address"},{"indexed":true,"internalType":"address","name":"token","type":"address"},{"indexed":true,"internalType":"address","name":"spender","type":"address"},{"indexed":false,"internalType":"uint160","name":"amount","type":"uint160"},{"indexed":false,"internalType":"uint48","name":"expiration","type":"uint48"}],"name":"Approval","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"owner","type":"address"},{"indexed":false,"internalType":"address","name":"token","type":"address"},{"indexed":false,"internalType":"address","name":"spender","type":"address"}],"name":"Lockdown","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"owner","type":"address"},{"indexed":true,"internalType":"address","name":"token","type":"address"},{"indexed":true,"internalType":"address","name":"spender","type":"address"},{"indexed":false,"internalType":"uint48","name":"newNonce","type":"uint48"},{"indexed":false,"internalType":"uint48","name":"oldNonce","type":"uint48"}],"name":"NonceInvalidation","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"owner","type":"address"},{"indexed":true,"internalType":"address","name":"token","type":"address"},{"indexed":true,"internalType":"address","name":"spender","type":"address"},{"indexed":false,"internalType":"uint160","name":"amount","type":"uint160"},{"indexed":false,"internalType":"uint48","name":"expiration","type":"uint48"},{"indexed":false,"internalType":"uint48","name":"nonce","type":"uint48"}],"name":"Permit","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"owner","type":"address"},{"indexed":false,"internalType":"uint256","name":"word","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"mask","type":"uint256"}],"name":"UnorderedNonceInvalidation","type":"event"},{"inputs":[],"name":"DOMAIN_SEPARATOR","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"","type":"address"},{"internalType":"address","name":"","type":"address"},{"internalType":"address","name":"","type":"address"}],"name":"allowance","outputs":[{"internalType":"uint160","name":"amount","type":"uint160"},{"internalType":"uint48","name":"expiration","type":"uint48"},{"internalType":"uint48","name":"nonce","type":"uint48"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"token","type":"address"},{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint160","name":"amount","type":"uint160"},{"internalType":"uint48","name":"expiration","type":"uint48"}],"name":"approve","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"token","type":"address"},{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint48","name":"newNonce","type":"uint48"}],"name":"invalidateNonces","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"wordPos","type":"uint256"},{"internalType":"uint256","name":"mask","type":"uint256"}],"name":"invalidateUnorderedNonces","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"components":[{"internalType":"address","name":"token","type":"address"},{"internalType":"address","name":"spender","type":"address"}],"internalType":"struct IAllowanceTransfer.TokenSpenderPair[]","name":"approvals","type":"tuple[]"}],"name":"lockdown","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"","type":"address"},{"internalType":"uint256","name":"","type":"uint256"}],"name":"nonceBitmap","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"owner","type":"address"},{"components":[{"components":[{"internalType":"address","name":"token","type":"address"},{"internalType":"uint160","name":"amount","type":"uint160"},{"internalType":"uint48","name":"expiration","type":"uint48"},{"internalType":"uint48","name":"nonce","type":"uint48"}],"internalType":"struct IAllowanceTransfer.PermitDetails[]","name":"details","type":"tuple[]"},{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"sigDeadline","type":"uint256"}],"internalType":"struct IAllowanceTransfer.PermitBatch","name":"permitBatch","type":"tuple"},{"internalType":"bytes","name":"signature","type":"bytes"}],"name":"permit","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"owner","type":"address"},{"components":[{"components":[{"internalType":"address","name":"token","type":"address"},{"internalType":"uint160","name":"amount","type":"uint160"},{"internalType":"uint48","name":"expiration","type":"uint48"},{"internalType":"uint48","name":"nonce","type":"uint48"}],"internalType":"struct IAllowanceTransfer.PermitDetails","name":"details","type":"tuple"},{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"sigDeadline","type":"uint256"}],"internalType":"struct IAllowanceTransfer.PermitSingle","name":"permitSingle","type":"tuple"},{"internalType":"bytes","name":"signature","type":"bytes"}],"name":"permit","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"components":[{"components":[{"internalType":"address","name":"token","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"internalType":"struct ISignatureTransfer.TokenPermissions","name":"permitted","type":"tuple"},{"internalType":"uint256","name":"nonce","type":"uint256"},{"internalType":"uint256","name":"deadline","type":"uint256"}],"internalType":"struct ISignatureTransfer.PermitTransferFrom","name":"permit","type":"tuple"},{"components":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"requestedAmount","type":"uint256"}],"internalType":"struct ISignatureTransfer.SignatureTransferDetails","name":"transferDetails","type":"tuple"},{"internalType":"address","name":"owner","type":"address"},{"internalType":"bytes","name":"signature","type":"bytes"}],"name":"permitTransferFrom","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"components":[{"components":[{"internalType":"address","name":"token","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"internalType":"struct ISignatureTransfer.TokenPermissions","name":"permitted","type":"tuple"},{"internalType":"uint256","name":"nonce","type":"uint256"},{"internalType":"uint256","name":"deadline","type":"uint256"}],"internalType":"struct ISignatureTransfer.PermitTransferFrom","name":"permit","type":"tuple"},{"components":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"requestedAmount","type":"uint256"}],"internalType":"struct ISignatureTransfer.SignatureTransferDetails","name":"transferDetails","type":"tuple"},{"internalType":"address","name":"owner","type":"address"},{"internalType":"bytes32","name":"witness","type":"bytes32"},{"internalType":"string","name":"witnessTypeString","type":"string"},{"internalType":"bytes","name":"signature","type":"bytes"}],"name":"permitWitnessTransferFrom","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"components":[{"components":[{"internalType":"address","name":"token","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"internalType":"struct ISignatureTransfer.TokenPermissions[]","name":"permitted","type":"tuple[]"},{"internalType":"uint256","name":"nonce","type":"uint256"},{"internalType":"uint256","name":"deadline","type":"uint256"}],"internalType":"struct ISignatureTransfer.PermitBatchTransferFrom","name":"permit","type":"tuple"},{"components":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"requestedAmount","type":"uint256"}],"internalType":"struct ISignatureTransfer.SignatureTransferDetails[]","name":"transferDetails","type":"tuple[]"},{"internalType":"address","name":"owner","type":"address"},{"internalType":"bytes32","name":"witness","type":"bytes32"},{"internalType":"string","name":"witnessTypeString","type":"string"},{"internalType":"bytes","name":"signature","type":"bytes"}],"name":"permitWitnessTransferFrom","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"components":[{"internalType":"address","name":"from","type":"address"},{"internalType":"address","name":"to","type":"address"},{"internalType":"uint160","name":"amount","type":"uint160"},{"internalType":"address","name":"token","type":"address"}],"internalType":"struct IAllowanceTransfer.AllowanceTransferDetails[]","name":"transferDetails","type":"tuple[]"}],"name":"transferFrom","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"from","type":"address"},{"internalType":"address","name":"to","type":"address"},{"internalType":"uint160","name":"amount","type":"uint160"},{"internalType":"address","name":"token","type":"address"}],"name":"transferFrom","outputs":[],"stateMutability":"nonpayable","type":"function"}]';
+                    const permit2Interface = new ethers.utils.Interface(permit2Abi);
+                    const permitTransferFromSelector = '0x30f28b7a';
+                    // for all TXs decode data and add to TX object
+                    for (let walletTx of walletTxs) {
+                        // get TX info
+                        log(`Getting tx info for hash: ${walletTx.hash}`);
+                        const txInfo = await provider.getTransaction(walletTx.hash);
+                        // if TX is not calling "permitTransferFrom" then skip it
+                        if (txInfo.data.substring(0, 10) !== permitTransferFromSelector) continue;
+                        // decode TX data
+                        const decodedTxData = permit2Interface.decodeFunctionData('permitTransferFrom', txInfo.data);
+                        // apply decoded TX data to wallet TX
+                        walletTx.decodedData = decodedTxData;
+                    }
+
+                    // init octokit
+                    const octokit = new Octokit({ auth: GITHUB_PERSONAL_ACCESS_TOKEN });
+                    const botNodeId = 'BOT_kgDOBr8EgA';
+                    // get all closed issues (in terms of github API a pull request is also an issue) 
+                    let issues = await octokit.paginate('GET /repos/{owner}/{repo}/issues', {
+                        owner: OWNER_NAME,
+                        repo: REPOSITORY_NAME,
+                        headers: {
+                            'X-GitHub-Api-Version': '2022-11-28'
+                        },
+                        state: 'closed',
+                        per_page: 100,
+                    });
+                    // remove PRs from the issues and find issues with at least 1 comment
+                    issues = issues.filter(issue => !issue.pull_request && issue.comments > 0);
+                    // for each closed issue
+                    for (let issue of issues) {
+                        // prepare result item
+                        let resultItem = {
+                            issueUrl: issue.html_url,
+                            txUrl: '',
+                            amount: '',
+                        };
+                        // get issue comments
+                        log(`Getting comments for issue: ${issue.number}`);
+                        const comments = await octokit.paginate('GET /repos/{owner}/{repo}/issues/{issue_number}/comments', {
+                            owner: OWNER_NAME,
+                            repo: REPOSITORY_NAME,
+                            issue_number: issue.number,
+                            headers: {
+                                'X-GitHub-Api-Version': '2022-11-28'
+                            }
+                        });
+                        // for each comment
+                        for (let comment of comments) {
+                            // if author is the ubiquity bot and the comment contains a claim URL
+                            const claimUrlRegExp = /https:\/\/pay\.ubq\.fi\?claim=[a-zA-Z0-9=]+/;
+                            if (comment.user.node_id == botNodeId && claimUrlRegExp.test(comment.body)) {
+                                // get base64 payload
+                                const base64Payload = comment.body.match(claimUrlRegExp)[0].replace('https://pay.ubq.fi?claim=', '');
+                                const payload = JSON.parse(atob(base64Payload));
+                                // find matching TX
+                                const matchingTxs = walletTxs.filter(walletTx => walletTx.decodedData && walletTx.decodedData.permit.nonce.toString() === payload.permit.nonce);
+                                if (matchingTxs.length > 0) {
+                                    resultItem.txUrl = `https://etherscan.io/tx/${matchingTxs[0].hash}`;
+                                    resultItem.amount =  ethers.utils.formatEther(payload.transferDetails.requestedAmount.toString());
+                                }
+                                break;
+                            }
+                        }
+                        // add result item
+                        results.push(resultItem);
+                    }
+                } catch (err) {
+                    alert(err);
+                    console.error(err);
+                }
+
+                return results;
+            }
+
+            /**
+             * Inserts a log string into html 
+             */
+            function log(msg) {
+                document.querySelector("#log").innerHTML = msg;
+            }
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
Resolves #22 

This PR adds the "audit page" where a treasurer can match issue payout with an ethereum transaction.

How to test:
1. Fill in params (@pavlovcik DMed you params for testing purposes):
 
<img width="1512" alt="Screenshot 2023-04-07 at 10 53 09" src="https://user-images.githubusercontent.com/119500907/230568408-2f850593-b48e-4f1e-8169-a5bb266a8bfc.png">

2. Click "Get report":
<img width="1512" alt="Screenshot 2023-04-07 at 10 55 30" src="https://user-images.githubusercontent.com/119500907/230568467-7b9a7190-6b3c-4426-89e1-b9c43bed5317.png">


If the concept is fine we can add more features like custom css, retries on error, etc...