### PR TITLE
ci: cloudflare single deploy

### DIFF
--- a/.github/workflows/continuous-deploy.yml
+++ b/.github/workflows/continuous-deploy.yml
@@ -2,11 +2,9 @@ name: Cloudflare Preview Deployment
 
 on:
   push:
-    branches-ignore:
-      - main
+    branches:
+      - development
   pull_request:
-    branches-ignore:
-      - main
 
 jobs:
   deploy-to-cloudflare:


### PR DESCRIPTION
Previously a cloudflare preview deploy was running 2 times per a single commit. This PR fixes it to run only once.