### PR TITLE
Invalidate nonce

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -100,6 +100,16 @@
                     <path d="M382 802 168 588l38-38 176 176 374-374 38 38-412 412Z" />
                   </svg>
                 </button>
+                <button id="invalidateBtn" style="display: none">
+                  <div>Invalidate</div>
+                  <svg width="20" height="20" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                      d="M420.48 121.813 390.187 91.52 256 225.92 121.813 91.52 91.52 121.813 225.92 256 91.52 390.187l30.293 30.293L256 286.08l134.187 134.4 30.293-30.293L286.08 256z"
+                      fill="#000"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </button>
               </div>
             </td>
           </tr>

--- a/static/index.html
+++ b/static/index.html
@@ -101,7 +101,7 @@
                   </svg>
                 </button>
                 <button id="invalidateBtn" style="display: none">
-                  <div>Invalidate</div>
+                  <div>Void</div>
                   <svg width="20" height="20" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
                     <path
                       d="M420.48 121.813 390.187 91.52 256 225.92 121.813 91.52 91.52 121.813 225.92 256 91.52 390.187l30.293 30.293L256 286.08l134.187 134.4 30.293-30.293L286.08 256z"

--- a/static/scripts/pay.ts
+++ b/static/scripts/pay.ts
@@ -160,7 +160,7 @@ const checkPermitClaimed = async () => {
   let tx = window.txData;
 
   // Set contract address and ABI
-  const provider = new ethers.providers.JsonRpcProvider(chainRpc[claimChainId]);
+  const provider = new ethers.providers.JsonRpcProvider(networkRpc[claimNetworkId]);
   const permit2Contract = new ethers.Contract(permit2Address, permit2Abi, provider);
 
   const { wordPos, bitPos } = nonceBitmap(BigNumber.from(tx.permit.nonce));


### PR DESCRIPTION
resolves #73 

I fixed the `checkPermitClaimed` because it was not checking just one bit but the whole bitmap, so if two nonces would have the same first 248 bits then the previous algorithm would say that both nonces are claimed even though they are not. In the new version it only checks the bit specified by the last 8 bits of the nonce.

