### PR TITLE
feat(audit): parse full and short URLs

### DIFF
--- a/static/scripts/audit-report/helpers.ts
+++ b/static/scripts/audit-report/helpers.ts
@@ -74,7 +74,7 @@ export const getGitHubUrlPartsArray = (urls: string[]): GitHubUrlParts[] => {
   const githubUrlPartsArray: GitHubUrlParts[] = [];
 
   for (const url of urls) {
-    const regex = /^https:\/\/github\.com\/([^/]+)\/([^/]+)$/i;
+    const regex = /([^/]+)\/([^/]+)$/i;
     const matches = url.match(regex);
     if (matches && matches.length === 3) {
       const owner = matches[1];


### PR DESCRIPTION
Right now the audit page requires full repo URLs to be defined

This PR makes it possible to define repo URLs in 2 ways: full URLs (ex: `https://github.com/ubiquity/pay.ubq.fi`) and short ones (ex: `ubiquity/pay.ubq.fi`)