### PR TITLE
fix: display all permitted issues in audit

### DIFF
--- a/static/scripts/audit-report/audit.ts
+++ b/static/scripts/audit-report/audit.ts
@@ -356,8 +356,8 @@ const commentFetcher = async () => {
                           owner,
                           repo,
                           bounty_hunter: {
-                            name: issueList[0].assignee?.login,
-                            url: issueList[0].assignee?.html_url
+                            name: issueList[0].assignee ? issueList[0].assignee.login : issueList[0].assignees[0]?.login,
+                            url: issueList[0].assignee ? issueList[0].assignee.html_url : issueList[0].assignees[0]?.html_url
                           }
                         },
                         ether: undefined,

--- a/static/scripts/audit-report/audit.ts
+++ b/static/scripts/audit-report/audit.ts
@@ -356,8 +356,8 @@ const commentFetcher = async () => {
                           owner,
                           repo,
                           bounty_hunter: {
-                            name: issueList[0].assignee.login,
-                            url: issueList[0].assignee.html_url
+                            name: issueList[0].assignee?.login,
+                            url: issueList[0].assignee?.html_url
                           }
                         },
                         ether: undefined,
@@ -365,7 +365,6 @@ const commentFetcher = async () => {
                       },
                     });
                     isFound = true;
-                    break;
                   }
                 } else {
                   console.log('URL not found, skipping');


### PR DESCRIPTION
Fix an early exit from the comment analysis loop and a special case, where the claim permit for the same bounty was generated twice. The audit tool stopped and pointed at the first, wrong permit.

Resolves: #126

QA: 
![image](https://github.com/ubiquity/pay.ubq.fi/assets/88761781/00071a03-efe0-4259-9328-6b191680410a)
