### PR TITLE
fix: optimal RPC now removes faulty elements properly

### DIFF
--- a/static/scripts/rewards/rpc-optimization/get-fastest-rpc-provider.ts
+++ b/static/scripts/rewards/rpc-optimization/get-fastest-rpc-provider.ts
@@ -12,11 +12,12 @@ export async function getFastestRpcProvider(networkId: number) {
 
     // Get all valid latencies from localStorage and find the fastest RPC
     const sortedLatencies = validLatencies.sort((a, b) => a[1] - b[1]);
-    const optimalRPC = sortedLatencies[0][0].split("_").slice(0, -1).join("_"); // Remove the network ID from the key
+    const optimalRpc = sortedLatencies[0][0];
+    const optimalRpcName = optimalRpc.split("_").slice(0, -1).join("_"); // Remove the network ID from the key
 
     try {
-      const rpcProvider = new ethers.providers.JsonRpcProvider(optimalRPC, {
-        name: optimalRPC,
+      const rpcProvider = new ethers.providers.JsonRpcProvider(optimalRpcName, {
+        name: optimalRpcName,
         chainId: networkId,
       });
       // We check if the networks positively gives us a block when requested to ensure the network works
@@ -24,8 +25,8 @@ export async function getFastestRpcProvider(networkId: number) {
       await rpcProvider.getBlock(1);
       return rpcProvider;
     } catch (e) {
-      console.warn(`Failed to get a block using network ${optimalRPC}, will try with another.`);
-      delete latencies[optimalRPC];
+      console.warn(`Failed to get a block using network ${optimalRpc}, will try with another.`);
+      delete latencies[optimalRpc];
     }
   }
 


### PR DESCRIPTION

Resolves #205 

It worked during the tests because the faulty network was https://gnosis.api.onfinality.io/public. It so happens that there is a similar network at https://gnosis.api.onfinality.io/public_100. I didn't see that the ID of the network would be removed from the key in such case, leading to a `delete` of a key that actually didn't exist during the loop. This has been fixed by storing the untrimmed key in another variable to actually remember the real key value.

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
