### PR TITLE
hot-fix: use `window.ethereum`

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,5 +1,7 @@
 import { Ethereum } from "ethereum-protocol";
 
 declare global {
-  const ethereum: Ethereum;
+  interface Window {
+    ethereum: Ethereum;
+  }
 }

--- a/static/scripts/rewards/ButtonController.ts
+++ b/static/scripts/rewards/ButtonController.ts
@@ -11,7 +11,7 @@ export class ButtonController {
   }
 
   public showLoader(): void {
-    if (ethereum) {
+    if (window.ethereum) {
       this._controls.setAttribute(LOADER, "true");
     } else {
       throw new Error("Can not show loader without `ethereum`");
@@ -27,7 +27,7 @@ export class ButtonController {
   }
 
   public showMakeClaim(): void {
-    if (ethereum) {
+    if (window.ethereum) {
       this._controls.setAttribute(MAKE_CLAIM, "true");
     } else {
       throw new Error("Can not show make claim button without `ethereum`");
@@ -47,7 +47,7 @@ export class ButtonController {
   }
 
   public showInvalidator(): void {
-    if (ethereum) {
+    if (window.ethereum) {
       this._controls.setAttribute(INVALIDATOR, "true");
     } else {
       throw new Error("Can not show invalidator button without `ethereum`");

--- a/static/scripts/rewards/render-transaction/read-claim-data-from-url.ts
+++ b/static/scripts/rewards/render-transaction/read-claim-data-from-url.ts
@@ -36,13 +36,13 @@ export async function readClaimDataFromUrl(app: AppState) {
   } catch (e) {
     toaster.create("error", `${e}`);
   }
-  if (ethereum) {
+  if (window.ethereum) {
     try {
       app.signer = await connectWallet();
     } catch (error) {
       /* empty */
     }
-    ethereum.on("accountsChanged", () => {
+    window.ethereum.on("accountsChanged", () => {
       checkRenderMakeClaimControl(app).catch(console.error);
       checkRenderInvalidatePermitAdminControl(app).catch(console.error);
     });

--- a/static/scripts/rewards/render-transaction/render-transaction.ts
+++ b/static/scripts/rewards/render-transaction/render-transaction.ts
@@ -53,7 +53,7 @@ export async function renderTransaction(): Promise<Success> {
     if (app.claimTxs[app.reward.permit.nonce.toString()] !== undefined) {
       buttonController.showViewClaim();
       viewClaimButton.addEventListener("click", () => window.open(`${app.currentExplorerUrl}/tx/${app.claimTxs[app.reward.permit.nonce.toString()]}`));
-    } else if (ethereum) {
+    } else if (window.ethereum) {
       // requires wallet connection to claim
       buttonController.showMakeClaim();
       getMakeClaimButton().addEventListener("click", claimErc20PermitHandlerWrapper(app));

--- a/static/scripts/rewards/web3/connect-wallet.ts
+++ b/static/scripts/rewards/web3/connect-wallet.ts
@@ -4,7 +4,7 @@ import { buttonController, toaster } from "../toaster";
 
 export async function connectWallet(): Promise<JsonRpcSigner | null> {
   try {
-    const wallet = new ethers.providers.Web3Provider(ethereum);
+    const wallet = new ethers.providers.Web3Provider(window.ethereum);
 
     await wallet.send("eth_requestAccounts", []);
 

--- a/static/scripts/rewards/web3/verify-current-network.ts
+++ b/static/scripts/rewards/web3/verify-current-network.ts
@@ -5,18 +5,18 @@ import { notOnCorrectNetwork } from "./not-on-correct-network";
 
 // verifyCurrentNetwork checks if the user is on the correct network and displays an error if not
 export async function verifyCurrentNetwork(desiredNetworkId: number) {
-  if (!ethereum) {
+  if (!window.ethereum) {
     buttonController.hideAll();
     return;
   }
 
-  const web3provider = new ethers.providers.Web3Provider(ethereum);
+  const web3provider = new ethers.providers.Web3Provider(window.ethereum);
 
   const network = await web3provider.getNetwork();
   const currentNetworkId = network.chainId;
 
   // watch for network changes
-  ethereum.on("chainChanged", <T>(newNetworkId: T | string) => handleIfOnCorrectNetwork(parseInt(newNetworkId as string, 16), desiredNetworkId));
+  window.ethereum.on("chainChanged", <T>(newNetworkId: T | string) => handleIfOnCorrectNetwork(parseInt(newNetworkId as string, 16), desiredNetworkId));
 
   // if its not on ethereum mainnet, gnosis, or goerli, display error
   notOnCorrectNetwork(currentNetworkId, desiredNetworkId, web3provider);


### PR DESCRIPTION
Resolves https://github.com/ubiquity/pay.ubq.fi/pull/212#issuecomment-2024419599

- - I'm using Brave on ios here

- - I checked out commits about 4 days apart until it would work on mobile without any code changes then applied the changes to the commit in which they were first introduced and verified it would load on mobile. I verified that `development` wouldn't load from HEAD on mobile before merging these changes in and verifying that it would load afterwards

If the issue was that on mobile the UI would never finish loading but would work on a desktop then this resolves it, below are some related infos.

- https://eips.ethereum.org/EIPS/eip-6963

> An alternative discovery mechanism to window.ethereum for [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) providers which supports discovering multiple injected Wallet Providers in a web page using Javascript’s window events... Currently, Wallet Provider that offer browser extensions must inject their Ethereum providers ([EIP-1193](https://eips.ethereum.org/EIPS/eip-1193)) into the same window object window.ethereum; however, this creates conflicts for users that may install more than one browser extension.

- https://eips.ethereum.org/EIPS/eip-5749

> At present, window.ethereum is the prevailing method by which Ethereum-compatible applications interact with injected wallets.

- https://eips.ethereum.org/EIPS/eip-1193

> Historically, Providers have been made available as window.ethereum in web browsers, but this convention is not part of the specification.

![image](https://github.com/ubiquity/pay.ubq.fi/assets/106303466/ade3ae03-fd5a-4ccb-958f-5e7fde5ca799)