### PR TITLE
Improve setup-scripts for tests

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -5,6 +5,8 @@
   "useGitignore": true,
   "language": "en",
   "words": [
+    "funder",
+    "Funder",
     "binkey",
     "binsec",
     "chainlist",

--- a/cypress/scripts/anvil.ts
+++ b/cypress/scripts/anvil.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "child_process";
+// @ts-expect-error - Missing types
 import { RPCHandler } from "@ubiquity-dao/rpc-handler";
 
 function useHandler(networkId: number) {

--- a/cypress/scripts/anvil.ts
+++ b/cypress/scripts/anvil.ts
@@ -1,31 +1,14 @@
 import { spawnSync } from "child_process";
+import { useHandler } from "../../static/scripts/rewards/web3/use-rpc-handler";
 // @ts-expect-error - Missing types
 import { RPCHandler } from "@ubiquity-dao/rpc-handler";
 
-function useHandler(networkId: number) {
-  const config = {
-    networkId: networkId,
-    autoStorage: false,
-    cacheRefreshCycles: 5,
-    rpcTimeout: 5000,
-    networkName: null,
-    runtimeRpcs: null,
-    networkRpcs: null,
-  };
-
-  // No RPCs are tested at this point
-  return new RPCHandler(config);
-}
-
 class Anvil {
   rpcs: string[] = [];
-  rpcHandler: RPCHandler;
-
-  constructor() {
-    this.rpcHandler = useHandler(100);
-  }
+  rpcHandler: RPCHandler | null = null;
 
   async init() {
+    this.rpcHandler = await useHandler(100);
     console.log(`[RPCHandler] Fetching RPCs...`);
     await this.rpcHandler.testRpcPerformance();
     const latencies: Record<string, number> = this.rpcHandler.getLatencies();

--- a/cypress/scripts/anvil.ts
+++ b/cypress/scripts/anvil.ts
@@ -1,80 +1,79 @@
-/* eslint-disable sonarjs/no-duplicate-string */
-import { spawn } from "child_process";
+import { spawnSync } from "child_process";
+import { RPCHandler } from "@ubiquity-dao/rpc-handler";
 
-const url = "http://localhost:8545";
+function useHandler(networkId: number) {
+  const config = {
+    networkId: networkId,
+    autoStorage: false,
+    cacheRefreshCycles: 5,
+    rpcTimeout: 5000,
+    networkName: null,
+    runtimeRpcs: null,
+    networkRpcs: null,
+  };
 
-const anvil = spawn("anvil", ["--chain-id", "31337", "--fork-url", "https://gnosis-pokt.nodies.app", "--host", "127.0.0.1", "--port", "8545"], {
-  stdio: "inherit",
-});
+  // No RPCs are tested at this point
+  return new RPCHandler(config);
+}
 
-setTimeout(() => {
-  console.log(`\n\n Anvil setup complete \n\n`);
-}, 5000);
+class Anvil {
+  rpcs: string[] = [];
+  rpcHandler: RPCHandler;
 
-// anvil --chain-id 31337 --fork-url https://eth.llamarpc.com --host 127.0.0.1 --port 8546
-
-spawn("cast", ["rpc", "--rpc-url", url, "anvil_impersonateAccount", "0xba12222222228d8ba445958a75a0704d566bf2c8"], {
-  stdio: "inherit",
-});
-spawn(
-  "cast",
-  [
-    "send",
-    "--rpc-url",
-    url,
-    "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d",
-    "--unlocked",
-    "--from",
-    "0xba12222222228d8ba445958a75a0704d566bf2c8",
-    "transfer(address,uint256)(bool)",
-    "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
-    "337888400000000000000000",
-  ],
-  {
-    stdio: "inherit",
+  constructor() {
+    this.rpcHandler = useHandler(100);
   }
-);
-spawn(
-  "cast",
-  [
-    "send",
-    "--rpc-url",
-    url,
-    "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d",
-    "--unlocked",
-    "--from",
-    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-    "approve(address,uint256)(bool)",
-    "0x000000000022D473030F116dDEE9F6B43aC78BA3",
-    "9999999999999991111111119999999999999999",
-  ],
-  {
-    stdio: "inherit",
-  }
-);
-spawn(
-  "cast",
-  [
-    "send",
-    "--rpc-url",
-    url,
-    "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d",
-    "--unlocked",
-    "--from",
-    "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
-    "approve(address,uint256)(bool)",
-    "0x000000000022D473030F116dDEE9F6B43aC78BA3",
-    "999999999999999111119999999999999999",
-  ],
-  {
-    stdio: "inherit",
-  }
-);
 
-anvil.on("close", (code) => {
-  console.log(`Anvil exited with code ${code}`);
-});
+  async init() {
+    console.log(`[RPCHandler] Fetching RPCs...`);
+    await this.rpcHandler.testRpcPerformance();
+    const latencies: Record<string, number> = this.rpcHandler.getLatencies();
+    const sorted = Object.entries(latencies).sort(([, a], [, b]) => a - b);
+    console.log(
+      `Fetched ${sorted.length} RPCs.\nFastest: ${sorted[0][0]} (${sorted[0][1]}ms)\nSlowest: ${sorted[sorted.length - 1][0]} (${sorted[sorted.length - 1][1]}ms)`
+    );
 
-anvil.on("error", (err) => {
-  console.error("Failed to start Anvil", err);
+    this.rpcs = sorted.map(([rpc]) => rpc.split("__")[1]);
+  }
+
+  async run() {
+    await this.init();
+    console.log(`Starting Anvil...`);
+    const isSuccess = await this.spawner(this.rpcs.shift());
+
+    if (!isSuccess) {
+      throw new Error(`Anvil failed to start`);
+    }
+  }
+
+  async spawner(rpc?: string): Promise<boolean> {
+    if (!rpc) {
+      console.log(`No RPCs left to try`);
+      return false;
+    }
+
+    console.log(`Forking with RPC: ${rpc}`);
+
+    const anvil = spawnSync("anvil", ["--chain-id", "31337", "--fork-url", rpc, "--host", "127.0.0.1", "--port", "8545"], {
+      stdio: "inherit",
+    });
+
+    if (anvil.status !== 0) {
+      console.log(`Anvil failed to start with RPC: ${rpc}`);
+      console.log(`Retrying with next RPC...`);
+      return this.spawner(this.rpcs.shift());
+    }
+
+    return true;
+  }
+}
+
+async function main() {
+  const anvil = new Anvil();
+  await anvil.run();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
 });

--- a/cypress/scripts/funding.ts
+++ b/cypress/scripts/funding.ts
@@ -1,0 +1,260 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+import { spawnSync } from "child_process";
+
+/**
+ * Handles the async funding of the testing environment
+ * specifically for use within a GitHub Action.
+ *
+ * Attempts to make tests more reliable by ensuring that the
+ * correct allowances and balances are set before running tests.
+ *
+ * Will attempt to retry a failed action up to 5 times max.
+ */
+
+class TestFunder {
+  anvilRPC = "http://localhost:8545";
+  fundingWallet = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
+  beneficiary = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+  permit2 = "0x000000000022D473030F116dDEE9F6B43aC78BA3";
+  WXDAI = "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d";
+  whale = "0xba12222222228d8ba445958a75a0704d566bf2c8";
+  expected = {
+    allowance: "999999999999999111119999999999999999",
+    balance: "337888400000000000000000",
+  };
+
+  loader() {
+    const steps = ["|", "/", "-", "\\"];
+    let i = 0;
+    return setInterval(() => {
+      process.stdout.write(`\r${steps[i++]}`);
+      i = i % steps.length;
+    }, 100);
+  }
+
+  async execute() {
+    const loader = this.loader();
+
+    let isMoving = true;
+
+    while (isMoving) {
+      console.log(`Attempting to fund the testing environment`);
+      if (!(await this._impersonateAccount(this.whale))) {
+        console.log(`Failed to impersonate account -> retrying...`);
+        const isSuccess = await this.retry(() => this._impersonateAccount(this.whale));
+
+        if (!isSuccess) {
+          console.log(`Failed to impersonate account -> exiting...`);
+          isMoving = false;
+        }
+      }
+
+      console.log(`Approving for funding wallet`);
+      if (!(await this._approvePayload(this.fundingWallet))) {
+        console.log(`Failed to approve funding wallet -> retrying...`);
+        const isSuccess = await this.retry(() => this._approvePayload(this.fundingWallet));
+
+        if (!isSuccess) {
+          console.log(`Failed to approve funding wallet -> exiting...`);
+          isMoving = false;
+        }
+      }
+
+      console.log(`Approving for beneficiary wallet`);
+      if (!(await this._approvePayload(this.beneficiary))) {
+        console.log(`Failed to approve beneficiary wallet -> retrying...`);
+        const isSuccess = await this.retry(() => this._approvePayload(this.beneficiary));
+
+        if (!isSuccess) {
+          console.log(`Failed to approve beneficiary wallet -> exiting...`);
+          isMoving = false;
+        }
+      }
+
+      console.log(`Transferring funds to funding wallet`);
+      if (!(await this._transferPayload())) {
+        console.log(`Failed to transfer funds to funding wallet -> retrying...`);
+        const isSuccess = await this.retry(() => this._transferPayload());
+
+        if (!isSuccess) {
+          console.log(`Failed to transfer funds to funding wallet -> exiting...`);
+          isMoving = false;
+        }
+      }
+
+      if (isMoving) {
+        console.log(`Funding complete`);
+        break;
+      }
+    }
+
+    await this.validate();
+    clearInterval(loader);
+  }
+
+  async retry(fn: () => Promise<any>, retries = 5) {
+    let i = 0;
+    let isSuccess = false;
+    while (i < retries) {
+      try {
+        isSuccess = await fn();
+      } catch (error) {
+        console.error(error);
+      }
+
+      if (isSuccess) return isSuccess;
+      i++;
+    }
+    throw new Error("Failed to execute function");
+  }
+
+  async validate() {
+    const allowance = await this._fundingAllowanceCheck();
+    const balance = await this._fundingBalanceCheck();
+
+    if (parseInt(allowance) < parseInt(this.expected.allowance)) {
+      throw new Error("Allowance is not set correctly");
+    }
+
+    if (parseInt(balance) < parseInt(this.expected.balance)) {
+      throw new Error("Balance is not set correctly");
+    }
+
+    console.log(`Funding wallet is ready for testing`);
+    console.log(`Allowance: ${allowance}\n Balance: ${balance}`);
+  }
+
+  private async _exec(payload: { command: string; args: string[]; options: any }) {
+    const { command, args, options } = payload;
+    const result = spawnSync(command, args, options);
+    if (result.error) {
+      throw result.error;
+    }
+    return result;
+  }
+
+  // pretend to be the whale
+  private async _impersonateAccount(address: string) {
+    const impersonate = await this._exec({
+      command: "cast",
+      args: ["rpc", "--rpc-url", this.anvilRPC, "anvil_impersonateAccount", address],
+      options: { stdio: "inherit" },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    return impersonate.status === 0;
+  }
+
+  private async _fundingAllowanceCheck() {
+    const allowance = await this._exec({
+      command: "cast",
+      args: ["call", this.WXDAI, "allowance(address,address)(uint256)", this.fundingWallet, this.permit2, "--rpc-url", this.anvilRPC],
+      options: { encoding: "utf8" },
+    });
+
+    return allowance.stdout;
+  }
+  private async _fundingBalanceCheck() {
+    const balance = await this._exec({
+      command: "cast",
+      args: ["call", this.WXDAI, "balanceOf(address)(uint256)", this.fundingWallet, "--rpc-url", this.anvilRPC],
+      options: { encoding: "utf8" },
+    });
+
+    return balance.stdout;
+  }
+  private async _approvePayload(address: string) {
+    const approve = await this._exec({
+      command: "cast",
+      args: [
+        "send",
+        "--rpc-url",
+        this.anvilRPC,
+        this.WXDAI,
+        "--unlocked",
+        "--from",
+        address,
+        "approve(address,uint256)(bool)",
+        this.permit2,
+        this.expected.allowance,
+      ],
+      options: { stdio: "inherit" },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    return approve.status === 0;
+  }
+  private async _transferPayload() {
+    const balance = parseInt(await this._fundingBalanceCheck());
+    const expected = parseInt(this.expected.balance);
+
+    if (balance === expected) {
+      return true;
+    } else if (balance > expected) {
+      await this.retry(() => this._clearBalance());
+    }
+
+    const transfer = await this._exec({
+      command: "cast",
+      args: [
+        "send",
+        "--rpc-url",
+        this.anvilRPC,
+        this.WXDAI,
+        "--unlocked",
+        "--from",
+        this.whale,
+        "transfer(address,uint256)(bool)",
+        this.fundingWallet,
+        this.expected.balance,
+      ],
+      options: { stdio: "inherit" },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    return transfer.status === 0;
+  }
+
+  private async _clearBalance() {
+    console.log(`Funder was overfunded, clearing excess funds`);
+    const balance = parseInt(await this._fundingBalanceCheck());
+    const difference = BigInt(balance - parseInt(this.expected.balance));
+
+    const clear = await this._exec({
+      command: "cast",
+      args: [
+        "send",
+        "--rpc-url",
+        this.anvilRPC,
+        this.WXDAI,
+        "--unlocked",
+        "--from",
+        this.fundingWallet,
+        "transfer(address,uint256)(bool)",
+        this.whale,
+        difference.toString(),
+      ],
+      options: { stdio: "inherit" },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    return clear.status === 0;
+  }
+}
+
+async function main() {
+  const funder = new TestFunder();
+  await funder.execute();
+}
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  })
+  .finally(() => {
+    process.exit(0);
+  });

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:start": "yarn start",
     "test:run": "cypress run",
     "test:open": "cypress open",
-    "test:fund": "cast rpc  --rpc-url http://127.0.0.1:8545 anvil_impersonateAccount 0xba12222222228d8ba445958a75a0704d566bf2c8 & cast send --rpc-url http://127.0.0.1:8545 0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d --unlocked --from 0xba12222222228d8ba445958a75a0704d566bf2c8 \"transfer(address,uint256)(bool)\" 0x70997970C51812dc3A010C7d01b50e0d17dc79C8  337888400000000000000000 & cast send --rpc-url http://127.0.0.1:8545 0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d --unlocked --from 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 \"approve(address,uint256)(bool)\" 0x000000000022D473030F116dDEE9F6B43aC78BA3  9999999999999991111111119999999999999999 & cast send --rpc-url http://127.0.0.1:8545 0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d --unlocked --from 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 \"approve(address,uint256)(bool)\" 0x000000000022D473030F116dDEE9F6B43aC78BA3  999999999999999111119999999999999999 & cast send --rpc-url http://127.0.0.1:8545 0xfB9124a8Bd01c250942de7beeE1E50aB9Ce36493 --unlocked --from 0xba12222222228d8ba445958a75a0704d566bf2c8 --value 0.1ether"
+    "test:fund": "tsx cypress/scripts/funding.ts"
   },
   "keywords": [
     "typescript",

--- a/static/scripts/rewards/render-transaction/read-claim-data-from-url.ts
+++ b/static/scripts/rewards/render-transaction/read-claim-data-from-url.ts
@@ -2,7 +2,6 @@ import { createClient } from "@supabase/supabase-js";
 import { decodePermits } from "@ubiquibot/permit-generation/handlers";
 import { Permit } from "@ubiquibot/permit-generation/types";
 import { app, AppState } from "../app-state";
-import { useFastestRpc } from "../rpc-optimization/get-optimal-provider";
 import { toaster } from "../toaster";
 import { connectWallet } from "../web3/connect-wallet";
 import { checkRenderInvalidatePermitAdminControl, checkRenderMakeClaimControl } from "../web3/erc20-permit";

--- a/static/scripts/rewards/web3/use-rpc-handler.ts
+++ b/static/scripts/rewards/web3/use-rpc-handler.ts
@@ -2,7 +2,7 @@ import { RPCHandler } from "@ubiquity-dao/rpc-handler";
 import { AppState } from "../app-state";
 import { ethers } from "ethers";
 
-async function useHandler(networkId: number) {
+export async function useHandler(networkId: number) {
   const config = {
     networkId: networkId,
     autoStorage: true,


### PR DESCRIPTION
Resolves #229 

- added `rpc-handler` to pull a list of good RPCs to setup anvil with
- added a dedicated script for funding with retries
- improved the anvil setup script with retries 


QA:

- https://github.com/ubq-testing/pay.ubq.fi/actions/runs/9278460006/job/25529499603