### PR TITLE
fix: move controls into sight

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -66,7 +66,7 @@
               </td>
             </tr>
           </thead>
-          <tbody id="mainTableBody">
+          <tbody>
             <tr id="Amount">
               <th>
                 <div>Amount</div>

--- a/static/index.html
+++ b/static/index.html
@@ -66,7 +66,7 @@
               </td>
             </tr>
           </thead>
-          <tbody>
+          <tbody id="mainTableBody">
             <tr id="Amount">
               <th>
                 <div>Amount</div>

--- a/static/scripts/rewards/render-transaction/render-transaction.ts
+++ b/static/scripts/rewards/render-transaction/render-transaction.ts
@@ -30,6 +30,7 @@ export async function renderTransaction(): Promise<Success> {
 
   if (isErc20Permit(app.reward)) {
     const treasury = await fetchTreasury(app.reward);
+    table.setAttribute(`data-additional-data-size`, "small");
 
     // insert tx data into table
     const requestedAmountElement = insertErc20PermitTableData(app, table, treasury);

--- a/static/scripts/rewards/render-transaction/render-transaction.ts
+++ b/static/scripts/rewards/render-transaction/render-transaction.ts
@@ -63,6 +63,7 @@ export async function renderTransaction(): Promise<Success> {
   } else {
     const requestedAmountElement = insertErc721PermitTableData(app.reward, table);
     table.setAttribute(`data-make-claim`, "ok");
+    table.setAttribute(`data-additional-data-size`, "large");
     renderNftSymbol({
       tokenAddress: app.reward.tokenAddress,
       explorerUrl: networkExplorers[app.reward.networkId],
@@ -71,7 +72,7 @@ export async function renderTransaction(): Promise<Success> {
     }).catch(console.error);
 
     const toElement = document.getElementById(`rewardRecipient`) as Element;
-    renderEnsName({ element: toElement, address: app.reward.beneficiary }).catch(console.error);
+    renderEnsName({ element: toElement, address: app.reward.beneficiary, networkID: app.networkId }).catch(console.error);
 
     getMakeClaimButton().addEventListener("click", claimErc721PermitHandler(app.reward));
   }

--- a/static/styles/rewards/claim-table.css
+++ b/static/styles/rewards/claim-table.css
@@ -150,7 +150,7 @@ table[data-make-claim-rendered] button.hide > svg#claim-icon {
   display: unset;
 }
 table[data-details-visible="true"][data-additional-data-size="large"] #mainTableBody {
-  transform: translate(-50%, 15%);
+  transform: translate(-50%, 20px);
 }
 table #controls {
   opacity: 0;

--- a/static/styles/rewards/claim-table.css
+++ b/static/styles/rewards/claim-table.css
@@ -149,9 +149,6 @@ table[data-make-claim-rendered] button.show > svg#claim-loader {
 table[data-make-claim-rendered] button.hide > svg#claim-icon {
   display: unset;
 }
-table[data-details-visible="true"][data-additional-data-size="large"] #mainTableBody {
-  transform: translate(-50%, 20px);
-}
 table #controls {
   opacity: 0;
   transition: 1s ease-in-out opacity;
@@ -172,6 +169,11 @@ table #additionalDetailsTable {
   opacity: 0;
   pointer-events: none;
   transform: translate(-50%, -90px);
+}
+table[data-additional-data-size="large"] #additionalDetailsTable {
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, -175px);
 }
 table[data-details-visible="true"] #additionalDetailsTable {
   opacity: 1;

--- a/static/styles/rewards/claim-table.css
+++ b/static/styles/rewards/claim-table.css
@@ -149,6 +149,9 @@ table[data-make-claim-rendered] button.show > svg#claim-loader {
 table[data-make-claim-rendered] button.hide > svg#claim-icon {
   display: unset;
 }
+table[data-details-visible="true"][data-additional-data-size="large"] #mainTableBody {
+  transform: translate(-50%, 15%);
+}
 table #controls {
   opacity: 0;
   transition: 1s ease-in-out opacity;


### PR DESCRIPTION
Resolves #247

The add. table is well placed and it didn't feel right moving it up any further


- applies `transform` and moves `mainTableBody` into sight only for NFTs

Before:

https://github.com/ubiquity/pay.ubq.fi/assets/106303466/8566ed05-0dca-45f7-b95f-9eece705066c


After:

https://github.com/ubiquity/pay.ubq.fi/assets/106303466/27661f1f-359e-4cd9-8156-b5e4776d17a2


