### PR TITLE
fix: use new deploy workflow to use new naming

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,5 +34,8 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: static
-          path: static
+          name: full-stack-app
+          path: |
+            static
+            package.json
+            yarn.lock

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,13 +17,14 @@ jobs:
         with:
           repository: ${{ github.repository }}
           production_branch: ${{ github.event.repository.default_branch }}
-          build_artifact_name: "static"
-          output_directory: "static"
+          build_artifact_name: "full-stack-app"
+          output_directory: "full-stack-app"
           current_branch: ${{ github.event.workflow_run.head_branch }}
           cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           commit_sha: ${{ github.event.workflow_run.head_sha }}
           workflow_run_id: ${{ github.event.workflow_run.id }}
+          statics_directory: "static"
 
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,6 @@ on:
     workflows: ["Build"]
     types:
       - completed
-  push:
 
 jobs:
   deploy-to-cloudflare:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     workflows: ["Build"]
     types:
       - completed
+  push:
 
 jobs:
   deploy-to-cloudflare:


### PR DESCRIPTION
Resolves https://github.com/ubiquity/cloudflare-deploy-action/pull/13#issuecomment-2175648131

Github uses `deploy.yml` only from the default branch `development`. We need this in the default branch to work for both, our new and old code from https://github.com/ubiquity/pay.ubq.fi/pull/226

Can we merge this asap to try it? 

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
