### PR TITLE
optimistic view claim rendering

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -41,7 +41,8 @@
     "URLSAFE",
     "WXDAI",
     "XDAI",
-    "xmark"
+    "xmark",
+    "outfile"
   ],
   "dictionaries": ["typescript", "node", "software-terms", "html"],
   "import": ["@cspell/dict-typescript/cspell-ext.json", "@cspell/dict-node/cspell-ext.json", "@cspell/dict-software-terms"],

--- a/static/scripts/rewards/web3/erc20-permit.ts
+++ b/static/scripts/rewards/web3/erc20-permit.ts
@@ -137,9 +137,7 @@ export function claimErc20PermitHandlerWrapper(app: AppState) {
     const tx: TransactionResponse = await transferFromPermit(permit2Contract, app);
     if (!tx) return;
 
-    viewClaimButton.onclick = () => {
-      window.open(`https://blockscan.com/tx/${tx.hash}`, "_blank");
-    };
+    viewClaimButton.onclick = () => window.open(`https://blockscan.com/tx/${tx.hash}`, "_blank");
 
     buttonController.showViewClaim();
     buttonController.hideLoader();

--- a/static/scripts/rewards/web3/erc20-permit.ts
+++ b/static/scripts/rewards/web3/erc20-permit.ts
@@ -100,15 +100,9 @@ async function transferFromPermit(permit2Contract: Contract, app: AppState) {
 async function waitForTransaction(tx: TransactionResponse) {
   try {
     const receipt = await tx.wait();
-    viewClaimButton.onclick = () => {
-      window.open(`https://blockscan.com/tx/${receipt.transactionHash}`, "_blank");
-    };
 
-    toaster.create("success", `Claim Complete.`);
-    buttonController.showViewClaim();
-    buttonController.hideLoader();
-    buttonController.hideMakeClaim();
     console.log(receipt.transactionHash);
+    toaster.create("success", `Claim Complete.`);
 
     return receipt;
   } catch (error: unknown) {
@@ -140,8 +134,16 @@ export function claimErc20PermitHandlerWrapper(app: AppState) {
     const permit2Contract = new ethers.Contract(permit2Address, permit2Abi, signer);
     if (!permit2Contract) return;
 
-    const tx = await transferFromPermit(permit2Contract, app);
+    const tx: TransactionResponse = await transferFromPermit(permit2Contract, app);
     if (!tx) return;
+
+    viewClaimButton.onclick = () => {
+      window.open(`https://blockscan.com/tx/${tx.hash}`, "_blank");
+    };
+
+    buttonController.showViewClaim();
+    buttonController.hideLoader();
+    buttonController.hideMakeClaim();
 
     const receipt = await waitForTransaction(tx);
     if (!receipt) return;


### PR DESCRIPTION
This should make the UI appear quicker because we are no longer awaiting the transaction to be confirmed onchain before allowing the tx be viewed on a block explorer. The loading mechanic once the wallet prompt is confirmed should disappear almost instantly as we have the `tx.hash` already. 

- render the `view claim` button before we await the `tx`
- still produce the success toast after we await the `tx`