### PR TITLE
style: restore logo css

### DIFF
--- a/static/styles/rewards/pay.css
+++ b/static/styles/rewards/pay.css
@@ -64,17 +64,16 @@ a {
 #logo > #logo-icon {
   display: inline-block;
   vertical-align: middle;
-  padding: 4px;
   text-rendering: geometricPrecision;
 }
 
 #logo-icon > svg {
-  height: 36px;
+  height: 28px;
   display: block;
   margin: 0;
-  width: 36px;
+  width: 28px;
   padding: 0;
-  margin-right: 10px;
+  margin-right: 6px;
   fill: #fff;
 }
 
@@ -82,17 +81,15 @@ a {
   display: inline-block;
   vertical-align: middle;
 }
-#logo > div#logo-text > span::after {
-  content: " ";
-  display: inline-block;
-  width: 8px;
-}
+
 #logo > div#logo-text > span {
-  font-size: 20px;
-  letter-spacing: 5px;
+  line-height: 1;
+  font-size: 16px;
+  letter-spacing: 2px;
   text-transform: uppercase;
   text-rendering: geometricPrecision;
   color: #fff;
+  font-weight: 400;
 }
 
 div.footer > div {


### PR DESCRIPTION
Resolves https://github.com/ubiquity/pay.ubq.fi/issues/339

I've double checked all of the css styles changes between "pre gift card mint" and "post gift card mint" branches:
- logo css styles are restored
- all other css styles are inplace (almost untouched)