### PR TITLE
feat: use reloadly production proxy

### DIFF
--- a/functions/helpers.ts
+++ b/functions/helpers.ts
@@ -52,7 +52,7 @@ export async function getAccessToken(env: Env): Promise<AccessToken> {
 
 export function getBaseUrl(isSandbox: boolean): string {
   if (isSandbox === false) {
-    return "https://giftcards.reloadly.com";
+    return "https://web3-gateway-test.com/proxy/reloadly/production";
   }
   return "https://giftcards-sandbox.reloadly.com";
 }


### PR DESCRIPTION
This PR uses a proxy URL with whitelisted ip in reloadly dashboard for minting real gift cards.

I've tried to add it to env variable but it followed a whole bunch of refactors because we have to pass the `ctx.env` object literally to all of the helper methods. I'll address it in a separate PR.

Notes:
1. This is a temporary solution since we need reloadly gift cards to be working for https://githubuniverse.com/
2. The `web3-gateway-test.com` domain DNS is not yet resolved for some of the countries. For example, it doesn't work in Germany and Belgium, but does work in Latvia. 

