### PR TITLE
PR: retry mint for a failed payment card order

### DIFF
--- a/functions/get-order.ts
+++ b/functions/get-order.ts
@@ -43,10 +43,9 @@ export async function onRequest(ctx: Context): Promise<Response> {
 
 export async function getTransactionFromOrderId(orderId: string, accessToken: AccessToken): Promise<OrderTransaction> {
   const nowFormatted = new Date().toISOString().replace("T", " ").substring(0, 19); //// yyyy-mm-dd HH:mm:ss
-  const oneYearAgo = new Date(new Date().setFullYear(new Date().getFullYear() - 1));
-  const oneYearAgoFormatted = oneYearAgo.toISOString().replace("T", " ").substring(0, 19);
+  const epochStartFormatted = "1970-01-01 00:00:00";
 
-  const url = `${getReloadlyApiBaseUrl(accessToken.isSandbox)}/reports/transactions?size=1&page=1&customIdentifier=${orderId}&startDate=${oneYearAgoFormatted}&endDate=${nowFormatted}`;
+  const url = `${getReloadlyApiBaseUrl(accessToken.isSandbox)}/reports/transactions?size=1&page=1&customIdentifier=${orderId}&startDate=${epochStartFormatted}&endDate=${nowFormatted}`;
   console.log(`Retrieving transaction from ${url}`);
   const options = {
     method: "GET",

--- a/functions/get-redeem-code.ts
+++ b/functions/get-redeem-code.ts
@@ -1,5 +1,5 @@
 import { verifyMessage } from "@ethersproject/wallet";
-import { getGiftCardOrderId, getMessageToSign } from "../shared/helpers";
+import { getGiftCardOrderId, getRevealMessageToSign } from "../shared/helpers";
 import { getRedeemCodeParamsSchema } from "../shared/api-types";
 import { getTransactionFromOrderId } from "./get-order";
 import { commonHeaders, getAccessToken, getReloadlyApiBaseUrl } from "./utils/shared";
@@ -29,7 +29,7 @@ export async function onRequest(ctx: Context): Promise<Response> {
 
     const errorResponse = Response.json({ message: "Given details are not valid to redeem code." }, { status: 403 });
 
-    if (verifyMessage(getMessageToSign(transactionId), signedMessage) != wallet) {
+    if (verifyMessage(getRevealMessageToSign(transactionId), signedMessage) != wallet) {
       console.error(
         `Signed message verification failed: ${JSON.stringify({
           signedMessage,

--- a/functions/post-order.ts
+++ b/functions/post-order.ts
@@ -49,8 +49,6 @@ export async function onRequest(ctx: Context): Promise<Response> {
       throw new Error(`Given transaction has not been mined yet. Please wait for it to be mined.`);
     }
 
-    validateSignedMessage(result.data, txReceipt);
-
     let amountDaiWei;
     let orderId;
 
@@ -76,6 +74,8 @@ export async function onRequest(ctx: Context): Promise<Response> {
       if (errorResponse) {
         return errorResponse;
       }
+
+      validateSignedMessage(result.data, txReceipt);
 
       amountDaiWei = txParsed.args.transferDetails.requestedAmount;
       orderId = getGiftCardOrderId(txReceipt.from, txParsed.args.signature);

--- a/shared/api-types.ts
+++ b/shared/api-types.ts
@@ -19,7 +19,7 @@ export const postOrderParamsSchema = z.object({
   txHash: z.string(),
   chainId: z.coerce.number(),
   country: z.string(),
-  signedMessage: z.string(),
+  signedMessage: z.optional(z.string()),
 });
 
 export type PostOrderParams = z.infer<typeof postOrderParamsSchema>;

--- a/shared/api-types.ts
+++ b/shared/api-types.ts
@@ -19,6 +19,7 @@ export const postOrderParamsSchema = z.object({
   txHash: z.string(),
   chainId: z.coerce.number(),
   country: z.string(),
+  signedMessage: z.string(),
 });
 
 export type PostOrderParams = z.infer<typeof postOrderParamsSchema>;

--- a/shared/helpers.ts
+++ b/shared/helpers.ts
@@ -10,10 +10,21 @@ export function getGiftCardOrderId(rewardToAddress: string, signature: string) {
   return ethers.utils.keccak256(integrityBytes);
 }
 
-export function getMessageToSign(transactionId: number) {
+export function getRevealMessageToSign(transactionId: number) {
   return JSON.stringify({
     from: "pay.ubq.fi",
     transactionId: transactionId,
+  });
+}
+
+export function getMintMessageToSign(type: "permit" | "ubiquity-dollar", chainId: number, txHash: string, productId: number, country: string) {
+  return JSON.stringify({
+    from: "pay.ubq.fi",
+    type,
+    chainId,
+    txHash,
+    productId,
+    country,
   });
 }
 

--- a/static/scripts/rewards/gift-cards/mint/mint-action.ts
+++ b/static/scripts/rewards/gift-cards/mint/mint-action.ts
@@ -70,8 +70,6 @@ async function mintGiftCard(productId: number, app: AppState) {
       return;
     }
     await checkForMintingDelay(app);
-  } else {
-    toaster.create("error", "Card minting failed. Try again in a few minutes.");
   }
 }
 
@@ -113,8 +111,6 @@ async function claimPermitToCardTreasury(app: AppState) {
     storeIncompleteMintTx(app.reward.nonce, tx.hash);
     await waitForTransaction(tx, `Transaction confirmed. Minting your card now.`, app.signer.provider.network.chainId);
     return tx.hash;
-  } else {
-    toaster.create("error", "Connect your wallet to proceed.");
   }
 }
 

--- a/static/scripts/rewards/gift-cards/mint/mint-action.ts
+++ b/static/scripts/rewards/gift-cards/mint/mint-action.ts
@@ -9,9 +9,10 @@ import { toaster } from "../../toaster";
 import { checkPermitClaimable, transferFromPermit, waitForTransaction } from "../../web3/erc20-permit";
 import { getApiBaseUrl, getUserCountryCode } from "../helpers";
 import { initClaimGiftCard } from "../index";
-import { getGiftCardOrderId } from "../../../../../shared/helpers";
+import { getGiftCardOrderId, getMintMessageToSign } from "../../../../../shared/helpers";
 import { postOrder } from "../../../shared/api";
 import { getIncompleteMintTx, removeIncompleteMintTx, storeIncompleteMintTx } from "./mint-tx-tracker";
+import { PostOrderParams } from "../../../../../shared/api-types";
 
 export function attachMintAction(giftCard: GiftCard, app: AppState) {
   const mintBtn: HTMLElement | null = document.getElementById("mint");
@@ -37,22 +38,33 @@ async function mintGiftCard(productId: number, app: AppState) {
     toaster.create("error", "Connect your wallet.");
     return;
   }
+
   const country = await getUserCountryCode();
   if (!country) {
     toaster.create("error", "Failed to detect your location to pick a suitable card for you.");
     return;
   }
 
-  const txHash = getIncompleteMintTx(app.reward.nonce) || (await claimPermitToCardTreasury(app));
+  const txHash: string = getIncompleteMintTx(app.reward.nonce) || (await claimPermitToCardTreasury(app));
 
   if (txHash) {
+    let signedMessage = "";
+    try {
+      signedMessage = await app.signer.signMessage(getMintMessageToSign("permit", app.signer.provider.network.chainId, txHash, productId, country));
+    } catch (error) {
+      toaster.create("error", "You did not sign the message to mint a payment card.");
+      return;
+    }
+
     const order = await postOrder({
       type: "permit",
       chainId: app.signer.provider.network.chainId,
       txHash: txHash,
       productId,
       country: country,
-    });
+      signedMessage: signedMessage,
+    } as PostOrderParams);
+
     if (!order) {
       toaster.create("error", "Order failed. Try again in a few minutes.");
       return;

--- a/static/scripts/rewards/gift-cards/mint/mint-action.ts
+++ b/static/scripts/rewards/gift-cards/mint/mint-action.ts
@@ -48,7 +48,7 @@ async function mintGiftCard(productId: number, app: AppState) {
   const txHash: string = getIncompleteMintTx(app.reward.nonce) || (await claimPermitToCardTreasury(app));
 
   if (txHash) {
-    let signedMessage = "";
+    let signedMessage;
     try {
       signedMessage = await app.signer.signMessage(getMintMessageToSign("permit", app.signer.provider.network.chainId, txHash, productId, country));
     } catch (error) {

--- a/static/scripts/rewards/gift-cards/mint/mint-tx-tracker.ts
+++ b/static/scripts/rewards/gift-cards/mint/mint-tx-tracker.ts
@@ -1,0 +1,24 @@
+const storageKey = "incompleteMints";
+
+export function getIncompleteMintTx(permitNonce: string): string | null {
+  const incompleteClaims = localStorage.getItem(storageKey);
+  return incompleteClaims ? JSON.parse(incompleteClaims)[permitNonce] : null;
+}
+
+export function storeIncompleteMintTx(permitNonce: string, txHash: string) {
+  let incompleteClaims: { [key: string]: string } = { [permitNonce]: txHash };
+  const oldIncompleteClaims = localStorage.getItem(storageKey);
+  if (oldIncompleteClaims) {
+    incompleteClaims = { ...incompleteClaims, ...JSON.parse(oldIncompleteClaims) };
+  }
+  localStorage.setItem(storageKey, JSON.stringify(incompleteClaims));
+}
+
+export function removeIncompleteMintTx(permitNonce: string) {
+  const incompleteClaims = localStorage.getItem(storageKey);
+  if (incompleteClaims) {
+    const incompleteClaimsObj = JSON.parse(incompleteClaims);
+    delete incompleteClaimsObj[permitNonce];
+    localStorage.setItem(storageKey, JSON.stringify(incompleteClaimsObj));
+  }
+}

--- a/static/scripts/rewards/gift-cards/reveal/reveal-action.ts
+++ b/static/scripts/rewards/gift-cards/reveal/reveal-action.ts
@@ -1,4 +1,4 @@
-import { getMessageToSign } from "../../../../../shared/helpers";
+import { getRevealMessageToSign } from "../../../../../shared/helpers";
 import { RedeemCode, OrderTransaction } from "../../../../../shared/types";
 import { AppState } from "../../app-state";
 import { toaster } from "../../toaster";
@@ -12,10 +12,10 @@ export function attachRevealAction(transaction: OrderTransaction, app: AppState)
     const transactionId = document.getElementById("redeem-code")?.getAttribute("data-transaction-id");
     if (app?.signer && transactionId) {
       try {
-        const signedMessage = await app.signer.signMessage(getMessageToSign(Number(transactionId)));
+        const signedMessage = await app.signer.signMessage(getRevealMessageToSign(Number(transactionId)));
         await revealRedeemCode(transaction.transactionId, signedMessage, app);
       } catch (error) {
-        toaster.create("error", "User did not sign the message to reveal redeem code.");
+        toaster.create("error", "You did not sign the message to reveal redeem code.");
         revealBtn.setAttribute(loaderAttribute, "false");
       }
     } else {

--- a/static/scripts/ubiquity-dollar/gift-card.ts
+++ b/static/scripts/ubiquity-dollar/gift-card.ts
@@ -1,5 +1,5 @@
 import { isAllowed } from "../../../shared/allowed-country-list";
-import { getGiftCardOrderId, getMessageToSign, isGiftCardAvailable } from "../../../shared/helpers";
+import { getGiftCardOrderId, getRevealMessageToSign, isGiftCardAvailable } from "../../../shared/helpers";
 import { GiftCard, OrderTransaction, RedeemCode } from "../../../shared/types";
 import { getUserCountryCode } from "../rewards/gift-cards/helpers";
 import { getRedeemCodeHtml } from "../rewards/gift-cards/reveal/redeem-code-html";
@@ -233,7 +233,7 @@ export function attachRevealAction(transaction: OrderTransaction) {
 
     if (signer && transactionId) {
       try {
-        const signedMessage = await signer.signMessage(getMessageToSign(Number(transactionId)));
+        const signedMessage = await signer.signMessage(getRevealMessageToSign(Number(transactionId)));
         await revealRedeemCode(transaction.transactionId, address, txHash, signedMessage);
       } catch (error) {
         toaster.create("error", "User did not sign the message to reveal redeem code.");

--- a/tests/unit/post-order.test.ts
+++ b/tests/unit/post-order.test.ts
@@ -186,6 +186,48 @@ describe("Post order for a payment card", () => {
     expect(await response.json()).toEqual({ message: "The reward has expired." });
   });
 
+  it("should return err for missing signed message", async () => {
+    await initMocks();
+    const request = new Request(`${TESTS_BASE_URL}/post-order`, {
+      method: "POST",
+      body: JSON.stringify({
+        type: "permit",
+        chainId: 31337,
+        txHash: "0xac3485ce523faa13970412a89ef42d10939b44abd33cbcff1ed84cb566a3a3d5",
+        productId: 18597,
+        country: "US",
+        signedMessage: "",
+      }),
+    }) as Request<unknown, IncomingRequestCfProperties<unknown>>;
+
+    const eventCtx = createEventContext(request, execContext);
+    const response = await pagesFunction(eventCtx);
+    await waitOnExecutionContext(execContext);
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ message: "Signed message is missing in the request." });
+  });
+
+  it("should return err for invalid signed message", async () => {
+    await initMocks();
+    const request = new Request(`${TESTS_BASE_URL}/post-order`, {
+      method: "POST",
+      body: JSON.stringify({
+        type: "permit",
+        chainId: 31337,
+        txHash: "0xac3485ce523faa13970412a89ef42d10939b44abd33cbcff1ed84cb566a3a3d5",
+        productId: 18597,
+        country: "US",
+        signedMessage: "0x1777a5bdb58d568f2d8bf7db8e248895097fa28d56f1bb89b098cbb20bf88cf1394efa20212beb0ed8d4c11fa43f52186c180b96e0ab2265f019b0d14e50ce9c1b",
+      }),
+    }) as Request<unknown, IncomingRequestCfProperties<unknown>>;
+
+    const eventCtx = createEventContext(request, execContext);
+    const response = await pagesFunction(eventCtx);
+    await waitOnExecutionContext(execContext);
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ message: "You have provided invalid signed message." });
+  });
+
   it("should return err order with tx hash that not permit2 interaction", async () => {
     await initMocks(receiptNotPermit2, minedTxNotPermit2);
 

--- a/tests/unit/post-order.test.ts
+++ b/tests/unit/post-order.test.ts
@@ -68,6 +68,7 @@ describe("Post order for a payment card", () => {
         txHash: "0xac3485ce523faa13970412a89ef42d10939b44abd33cbcff1ed84cb566a3a3d5",
         productId: 18597,
         country: "US",
+        signedMessage: "0x054114b71b08d0dbe6639a4810169a45591c96ebbba94f7540e1696499dd179418fe58c6e254fe84a99d19a04a502eefc990f88f8352a528f70cd54fe3a71a0b1c",
       }),
     }) as Request<unknown, IncomingRequestCfProperties<unknown>>;
 
@@ -88,6 +89,7 @@ describe("Post order for a payment card", () => {
         txHash: "0xac3485ce523faa13970412a89ef42d10939b44abd33cbcff1ed84cb566a3a3d5",
         productId: 18732,
         country: "US",
+        signedMessage: "0xab1c86111f7f5062ac0c0d44e7008c20cd92f3455aaf026ca0a53838a3dfa4b77e088ae5faa0ee0ceab31340986dcd9cb031001e5d730f730c52c1c4cfb3de0a1b",
       }),
     }) as Request<unknown, IncomingRequestCfProperties<unknown>>;
 
@@ -108,6 +110,7 @@ describe("Post order for a payment card", () => {
         txHash: "0xac3485ce523faa13970412a89ef42d10939b44abd33cbcff1ed84cb566a3a3d5",
         productId: 18597,
         country: "US",
+        signedMessage: "0x3258313920dfac47c13307e46260495ef2cdac180889673f624107dc8b2c1d343767d6b6c5dac10d7e5c945a671bc0a3efa4060c47e0d44c447c1416a56edf911b",
       }),
     }) as Request<unknown, IncomingRequestCfProperties<unknown>>;
 
@@ -129,6 +132,7 @@ describe("Post order for a payment card", () => {
         txHash: "0xf21e2ce3a5106c6ddd0d70c8925965878a2604ed042990be49b05773196bb6b4",
         productId: 18597,
         country: "US",
+        signedMessage: "0x3a6739343e99cd712e80acecad93cdb30723854b1febc81ed5e70b1db464c49e69cc45621281bf85b85455ba5d98aeeaf043ef4bb4947d535a721de5c9bcc1251c",
       }),
     }) as Request<unknown, IncomingRequestCfProperties<unknown>>;
 
@@ -150,6 +154,7 @@ describe("Post order for a payment card", () => {
         txHash: "0x9c9fd8cde45957741c16f0af4ab191d9b010c6f95d351df8c023e14a2ac80aa2",
         productId: 18597,
         country: "US",
+        signedMessage: "0x7a032fcf8746edc43502fe8264780d64df5a39e3d27716fef522d8bf2103521f5ec2c00ba43538247fd58c6ff63825f262b09f6f7edca5b4dcbf006b19fa0f761b",
       }),
     }) as Request<unknown, IncomingRequestCfProperties<unknown>>;
 
@@ -170,6 +175,7 @@ describe("Post order for a payment card", () => {
         txHash: "0xfac827e7448c6578f7a22f7f90ec64693ef54238164d50dd895567f382d3c0bb",
         productId: 18597,
         country: "US",
+        signedMessage: "0x1777a5bdb58d568f2d8bf7db8e248895097fa28d56f1bb89b098cbb20bf88cf1394efa20212beb0ed8d4c11fa43f52186c180b96e0ab2265f019b0d14e50ce9c1b",
       }),
     }) as Request<unknown, IncomingRequestCfProperties<unknown>>;
 
@@ -191,6 +197,7 @@ describe("Post order for a payment card", () => {
         txHash: "0xfac827e7448c6578f7a22f7f90ec64693ef54238164d50dd895567f382d3c0bb",
         productId: 18597,
         country: "US",
+        signedMessage: "0x1777a5bdb58d568f2d8bf7db8e248895097fa28d56f1bb89b098cbb20bf88cf1394efa20212beb0ed8d4c11fa43f52186c180b96e0ab2265f019b0d14e50ce9c1b",
       }),
     }) as Request<unknown, IncomingRequestCfProperties<unknown>>;
 
@@ -217,6 +224,7 @@ describe("Post order for a payment card", () => {
         txHash: "0xbef4c18032fbef0453f85191fb0fa91184b42d12ccc37f00eb7ae8c1d88a0233",
         productId: 18597,
         country: "US",
+        signedMessage: "0x3d436ff563e82f81c77fd69a9f484c90059b06a6e2b1bafacec8f2a55021b28b0f39cdab7729545499fd489e2a01b3faec39d44b47cde247cb5082c46a6e94971b",
       }),
     }) as Request<unknown, IncomingRequestCfProperties<unknown>>;
 
@@ -242,6 +250,7 @@ describe("Post order for a payment card", () => {
         txHash: "0xbef4c18032fbef0453f85191fb0fa91184b42d12ccc37f00eb7ae8c1d88a0233",
         productId: 18597,
         country: "US",
+        signedMessage: "0x3d436ff563e82f81c77fd69a9f484c90059b06a6e2b1bafacec8f2a55021b28b0f39cdab7729545499fd489e2a01b3faec39d44b47cde247cb5082c46a6e94971b",
       }),
     }) as Request<unknown, IncomingRequestCfProperties<unknown>>;
 
@@ -266,6 +275,7 @@ describe("Post order for a payment card", () => {
         txHash: "0xbef4c18032fbef0453f85191fb0fa91184b42d12ccc37f00eb7ae8c1d88a0233",
         productId: 18597,
         country: "US",
+        signedMessage: "0x3d436ff563e82f81c77fd69a9f484c90059b06a6e2b1bafacec8f2a55021b28b0f39cdab7729545499fd489e2a01b3faec39d44b47cde247cb5082c46a6e94971b",
       }),
     }) as Request<unknown, IncomingRequestCfProperties<unknown>>;
 
@@ -392,6 +402,7 @@ describe("Post order for a payment card", () => {
         txHash: "0xac3485ce523faa13970412a89ef42d10939b44abd33cbcff1ed84cb566a3a3d5",
         productId: 13959,
         country: "US",
+        signedMessage: "0x3d73c9509e8cbf15557046e4071a35ec7aa55b36015288a45dbbd9bcad5eb2b46799d7475759d353490d792a9e6fd66d559e1234b9c45910c526e0ae86b0f52d1c",
       }),
     }) as Request<unknown, IncomingRequestCfProperties<unknown>>;
 


### PR DESCRIPTION
Resolves #291

In issue specs, I suggested retrieving the transaction hash of the partially failed mint by reading the events of permit2. I tried that. Even though permit2 has events, but none of those events are for the claim. Because of this, the events of permit2 are of no use to us here.

In the current solution, we store the permit nonce and tx hash in local storage and use it in retry if the mint failed previously. This is good enough for us.

However, there is one drawback of this solution. When minting, the user has to provide two confirmations using their web3 wallet. One for the permit transaction, and the second to sign a message.   Moreover, the signing of message also provides an additional benefit. `/post-order` is open to public and anyone can call it if the transaction has partially failed but transferred the permit amount to card treasury. It was very useful if the best card for user was fixed. But the best card for user can change based on its location and availability. This adds risk as public can mint a wrong card. Signing of message removes this risk. Only actual user can retry mint after looking at currently available card for them.

## QA

https://github.com/user-attachments/assets/bd72fb01-23b0-4f21-8da0-f0eee1767ace




<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
