### PR TITLE
fix: use link instead of massive footer

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -175,9 +175,8 @@
       <div>
         <div id="gift-cards">Loading...</div>
         <div class="disclaimer">
-          <h2>Disclaimer</h2>
-          <p>All Visa/Mastercard are non-exchangeable & non-refundable.</p>
-          <p>Exact value of a card can be slightly different due to exchange rate.</p>
+          <a href="https://dao.ubq.fi/card-minting">View Disclaimer</a>
+        </div>
         </div>
       </div>
       <footer>

--- a/static/ubiquity-dollar.html
+++ b/static/ubiquity-dollar.html
@@ -91,11 +91,9 @@
       </div>
       <div id="transaction-history"></div>
       <div class="disclaimer">
-        <h2>Disclaimer</h2>
-        <p>All Visa/Mastercard are non-exchangeable & non-refundable.</p>
-        <p>Exact value of a card can be slightly different due to exchange rate.</p>
+        <a href="https://dao.ubq.fi/card-minting">View Disclaimer</a>
       </div>
-      <footer>
+    <footer>
         <div class="footer">
           <div id="build">
             <a target="_blank" rel="noopener noreferrer"></a>


### PR DESCRIPTION
Resolves #344

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

<img width="1020" alt="image" src="https://github.com/user-attachments/assets/d3aea911-6207-439b-a7e2-57267a1228f8" />

