### PR TITLE
Handle GitHub pull request URLs in formatGithubLink function

### DIFF
--- a/frontend/src/components/permit-row.tsx
+++ b/frontend/src/components/permit-row.tsx
@@ -134,7 +134,7 @@ export function PermitRow({
     } catch (e) {
       console.error("Error parsing GitHub URL:", e);
     }
-    return "Source Link lol";
+    return "Source Link";
   };
 
   const renderAmount = () => {


### PR DESCRIPTION
Resolves https://github.com/ubiquity-os-marketplace/text-conversation-rewards/issues/449

QA:
<img width="1158" height="646" alt="image" src="https://github.com/user-attachments/assets/161f4ced-35cd-48f1-a1b3-3f0b7ca98a4e" />

Also testable at https://pay-ubq-fi-6f38we1n78vn.deno.dev/

The user has a reward in a [pull-request](https://github.com/Meniole/text-conversation-rewards/pull/264#issuecomment-3569392804) which is in turn properly displayed. Sadly since tests have been removed, I cannot add a regression test for this.