### PR TITLE
Improve funding wallet permit delete UX

### DIFF
--- a/src/components/dashboard-page.tsx
+++ b/src/components/dashboard-page.tsx
@@ -8,6 +8,7 @@ import { usePermitClaiming } from "../hooks/use-permit-claiming.ts";
 import { usePermitData } from "../hooks/use-permit-data.ts";
 import { usePermitInvalidation } from "../hooks/use-permit-invalidation.ts";
 import { PermitData } from "../types.ts";
+import { getFundingWalletActionLabels } from "../utils/permit-invalidation-utils.ts";
 import { hasRequiredFields } from "../utils/permit-utils.ts";
 import { ICONS } from "./iconography.tsx";
 import { LogoSpan } from "./login-page.tsx";
@@ -221,6 +222,7 @@ export function DashboardPage() {
     () => isInvalidatingAny || (pendingNetworkSwitch.isSwitching && pendingNetworkSwitch.action === "invalidate"),
     [isInvalidatingAny, pendingNetworkSwitch.isSwitching, pendingNetworkSwitch.action]
   );
+  const fundingWalletActionLabels = getFundingWalletActionLabels(isInvalidationFlowActive, invalidatablePermitCount);
 
   const onInvalidatePermit = useCallback(
     async (permit: PermitData) => {
@@ -431,7 +433,7 @@ export function DashboardPage() {
                   : isClaimFlowActive || !isConnected || claimablePermitCount === 0
               }
               className="button-with-icon"
-              title={isFundingWallet ? "Invalidate all valid permits (batched by nonce bitmap)" : "Claim all valid and available permits (batch RPC)"}
+              title={isFundingWallet ? fundingWalletActionLabels.title : "Claim all valid and available permits (batch RPC)"}
             >
               {isFundingWallet ? (
                 isInvalidationFlowActive ? (
@@ -449,7 +451,7 @@ export function DashboardPage() {
               <span>
                 {isLoading ? (
                   isFundingWallet ? (
-                    "Loading Invalidations..."
+                    "Loading Deletes..."
                   ) : (
                     "Loading Rewards..."
                   )
@@ -459,10 +461,8 @@ export function DashboardPage() {
                   <>
                     {isFundingWallet ? (
                       <>
-                        <span className="claim-amount">Invalidate all</span>
-                        <span className="claim-count">
-                          ({invalidatablePermitCount} Permit{invalidatablePermitCount !== 1 ? "s" : ""})
-                        </span>
+                        <span className="claim-amount">{fundingWalletActionLabels.primaryText}</span>
+                        <span className="claim-count">{fundingWalletActionLabels.countText}</span>
                       </>
                     ) : isClaimFlowActive ? (
                       <>

--- a/src/components/permit-row.tsx
+++ b/src/components/permit-row.tsx
@@ -8,6 +8,7 @@ import { getTokenInfo } from "../constants/supported-reward-tokens.ts";
 import { config } from "../main.tsx";
 import type { PermitData } from "../types.ts";
 import { parseGitHubUrl, truncateAddress } from "../utils/format-utils.ts";
+import { getFundingWalletActionLabels } from "../utils/permit-invalidation-utils.ts";
 import { formatAmount, hasRequiredFields } from "../utils/permit-utils.ts";
 import { ICONS } from "./iconography.tsx";
 
@@ -59,6 +60,7 @@ export function PermitRow({
 
   const isOwner = !!address && permit.owner.toLowerCase() === address.toLowerCase();
   const canInvalidate = isOwner && !isClaimed && !isInvalidating;
+  const fundingWalletActionLabels = getFundingWalletActionLabels(isInvalidating, 1);
 
   const rowClassName = (() => {
     if (!isReadyToClaim) return "row-invalid";
@@ -77,9 +79,9 @@ export function PermitRow({
   const explorerUrl = chain?.blockExplorers?.default?.url;
 
   const statusDisplayText = (() => {
-    if (networkMismatch) return `Switch wallet to ${targetNetworkName} to ${isFundingWallet && isOwner ? "invalidate" : "claim"}`;
+    if (networkMismatch) return `Switch wallet to ${targetNetworkName} to ${isFundingWallet && isOwner ? "delete" : "claim"}`;
     if (isClaimed) return "Claimed";
-    if (isInvalidating) return "Invalidating...";
+    if (isInvalidating) return fundingWalletActionLabels.pendingText;
     if (isClaimingThis) return "Claiming...";
     if (claimFailed) return "Failed";
     if (insufficientBalance) return "Insolvent";
@@ -90,8 +92,8 @@ export function PermitRow({
   })();
 
   const buttonText = (() => {
-    if (isInvalidating) return "Invalidating...";
-    if (isFundingWallet && canInvalidate) return "Invalidate";
+    if (isInvalidating) return fundingWalletActionLabels.buttonText;
+    if (isFundingWallet && canInvalidate) return fundingWalletActionLabels.buttonText;
     if ((isClaimed || claimFailed) && permit.transactionHash) return "View";
     if (isClaimingThis) return "Claiming...";
     if (claimFailed) return "Retry";
@@ -268,7 +270,7 @@ export function PermitRow({
           onClick={handleButtonClick}
           disabled={isButtonDisabled}
           className={`button-with-icon ${isClaimed && permit.transactionHash ? "view-button" : ""}`}
-          title={statusDisplayText}
+          title={isFundingWallet && isOwner ? fundingWalletActionLabels.title : statusDisplayText}
         >
           {showButtonIcon && buttonIcon}
           <span>{finalButtonText}</span>

--- a/src/hooks/use-permit-invalidation.ts
+++ b/src/hooks/use-permit-invalidation.ts
@@ -2,6 +2,7 @@ import { useCallback, useState } from "react";
 import { Address, Chain, PublicClient, WalletClient } from "viem";
 import permit2Abi from "../fixtures/permit2-abi.ts";
 import { PermitData } from "../types.ts";
+import { deriveNonceBitmap, groupPermitsForInvalidation } from "../utils/permit-invalidation-utils.ts";
 
 interface UsePermitInvalidationProps {
   setPermits: React.Dispatch<React.SetStateAction<PermitData[]>>;
@@ -24,12 +25,6 @@ export function usePermitInvalidation({
 }: UsePermitInvalidationProps) {
   const [isInvalidating, setIsInvalidating] = useState<Record<string, boolean>>({});
 
-  const nonceBitmap = (nonce: bigint): { wordPos: bigint; bitPos: bigint } => {
-    const wordPos = nonce >> 8n;
-    const bitPos = nonce & 0xffn;
-    return { wordPos, bitPos };
-  };
-
   const handleInvalidatePermit = useCallback(
     async (permit: PermitData): Promise<{ success: boolean; txHash: string }> => {
       const permitKey = permit.signature;
@@ -50,13 +45,13 @@ export function usePermitInvalidation({
 
       try {
         const nonceBigInt = BigInt(permit.nonce);
-        const { wordPos, bitPos } = nonceBitmap(nonceBigInt);
+        const { wordPos, bitMask } = deriveNonceBitmap(nonceBigInt);
 
         const { request } = await publicClient.simulateContract({
           address: permit.permit2Address,
           abi: permit2Abi,
           functionName: "invalidateUnorderedNonces",
-          args: [wordPos, 1n << bitPos],
+          args: [wordPos, bitMask],
           account: address,
         });
 
@@ -116,34 +111,15 @@ export function usePermitInvalidation({
         return { success: false, txHashes: [] };
       }
 
-      const grouped = new Map<
-        string,
-        {
-          permit2Address: `0x${string}`;
-          wordPos: bigint;
-          mask: bigint;
-          signatures: string[];
-        }
-      >();
-
-      for (const permit of permits) {
-        const nonceBigInt = BigInt(permit.nonce);
-        const { wordPos, bitPos } = nonceBitmap(nonceBigInt);
-        const groupKey = `${permit.permit2Address.toLowerCase()}:${wordPos.toString()}`;
-        const existing = grouped.get(groupKey) ?? { permit2Address: permit.permit2Address, wordPos, mask: 0n, signatures: [] };
-        existing.mask |= 1n << bitPos;
-        existing.signatures.push(permit.signature);
-        grouped.set(groupKey, existing);
-      }
-
+      const groups = groupPermitsForInvalidation(permits);
       const txHashes: string[] = [];
       let success = true;
 
-      for (const group of grouped.values()) {
+      for (const group of groups) {
         const groupPermitKeys = Array.from(new Set(group.signatures));
         try {
           const { request } = await publicClient.simulateContract({
-            address: group.permit2Address,
+            address: group.permit2Address as `0x${string}`,
             abi: permit2Abi,
             functionName: "invalidateUnorderedNonces",
             args: [group.wordPos, group.mask],

--- a/src/utils/permit-invalidation-utils.ts
+++ b/src/utils/permit-invalidation-utils.ts
@@ -1,0 +1,62 @@
+type InvalidationPermitInput = Readonly<{
+  signature: string;
+  nonce: bigint | number | string;
+  permit2Address: `0x${string}` | string;
+}>;
+
+export type NonceBitmap = Readonly<{
+  wordPos: bigint;
+  bitPos: bigint;
+  bitMask: bigint;
+}>;
+
+export type InvalidationGroup = Readonly<{
+  permit2Address: `0x${string}` | string;
+  wordPos: bigint;
+  mask: bigint;
+  signatures: string[];
+}>;
+
+export type FundingWalletActionLabels = Readonly<{
+  primaryText: string;
+  countText: string;
+  buttonText: string;
+  pendingText: string;
+  title: string;
+}>;
+
+export function deriveNonceBitmap(nonce: bigint | number | string): NonceBitmap {
+  const nonceBigInt = BigInt(nonce);
+  const wordPos = nonceBigInt >> 8n;
+  const bitPos = nonceBigInt & 0xffn;
+  return { wordPos, bitPos, bitMask: 1n << bitPos };
+}
+
+export function groupPermitsForInvalidation(permits: readonly InvalidationPermitInput[]): InvalidationGroup[] {
+  const grouped = new Map<string, { permit2Address: `0x${string}` | string; wordPos: bigint; mask: bigint; signatures: string[] }>();
+
+  for (const permit of permits) {
+    const { wordPos, bitMask } = deriveNonceBitmap(permit.nonce);
+    const groupKey = `${permit.permit2Address.toLowerCase()}:${wordPos.toString()}`;
+    const existing = grouped.get(groupKey) ?? { permit2Address: permit.permit2Address, wordPos, mask: 0n, signatures: [] };
+
+    existing.mask |= bitMask;
+    existing.signatures.push(permit.signature);
+    grouped.set(groupKey, existing);
+  }
+
+  return Array.from(grouped.values());
+}
+
+export function getFundingWalletActionLabels(isPending: boolean, permitCount: number): FundingWalletActionLabels {
+  const countText = `(${permitCount} Permit${permitCount === 1 ? "" : "s"})`;
+  const pendingText = "Deleting...";
+
+  return {
+    primaryText: isPending ? pendingText : "Delete all",
+    countText,
+    buttonText: isPending ? pendingText : "Delete",
+    pendingText,
+    title: "Delete bogus permits by invalidating their Permit2 nonces on-chain",
+  };
+}

--- a/tests/permit-invalidation-utils.test.ts
+++ b/tests/permit-invalidation-utils.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { deriveNonceBitmap, getFundingWalletActionLabels, groupPermitsForInvalidation } from "../src/utils/permit-invalidation-utils";
+
+describe("deriveNonceBitmap", () => {
+  test("derives Permit2 unordered nonce word positions and bit masks", () => {
+    expect(deriveNonceBitmap(0n)).toEqual({ wordPos: 0n, bitPos: 0n, bitMask: 1n });
+    expect(deriveNonceBitmap(255n)).toEqual({ wordPos: 0n, bitPos: 255n, bitMask: 1n << 255n });
+    expect(deriveNonceBitmap(256n)).toEqual({ wordPos: 1n, bitPos: 0n, bitMask: 1n });
+  });
+});
+
+describe("groupPermitsForInvalidation", () => {
+  test("groups same Permit2 address and nonce word into a single bitmap transaction", () => {
+    const groups = groupPermitsForInvalidation([
+      { signature: "sig-a", nonce: 1n, permit2Address: "0xABC" },
+      { signature: "sig-b", nonce: 2n, permit2Address: "0xabc" },
+      { signature: "sig-c", nonce: 256n, permit2Address: "0xABC" },
+      { signature: "sig-d", nonce: 1n, permit2Address: "0xDEF" },
+    ]);
+
+    expect(groups).toEqual([
+      {
+        permit2Address: "0xABC",
+        wordPos: 0n,
+        mask: (1n << 1n) | (1n << 2n),
+        signatures: ["sig-a", "sig-b"],
+      },
+      {
+        permit2Address: "0xABC",
+        wordPos: 1n,
+        mask: 1n,
+        signatures: ["sig-c"],
+      },
+      {
+        permit2Address: "0xDEF",
+        wordPos: 0n,
+        mask: 1n << 1n,
+        signatures: ["sig-d"],
+      },
+    ]);
+  });
+});
+
+describe("getFundingWalletActionLabels", () => {
+  test("uses delete wording while explaining the on-chain invalidation action", () => {
+    expect(getFundingWalletActionLabels(false, 3)).toEqual({
+      primaryText: "Delete all",
+      countText: "(3 Permits)",
+      buttonText: "Delete",
+      pendingText: "Deleting...",
+      title: "Delete bogus permits by invalidating their Permit2 nonces on-chain",
+    });
+
+    expect(getFundingWalletActionLabels(true, 1)).toMatchObject({
+      primaryText: "Deleting...",
+      countText: "(1 Permit)",
+      buttonText: "Deleting...",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- changes the funding-wallet action wording from “Invalidate” to “Delete” while keeping the tooltip explicit that Permit2 nonces are invalidated on-chain
- extracts nonce bitmap derivation and batch grouping into a tested utility
- reuses the same labels in the header “delete all” action and per-permit row button

## Verification
- `bun run typecheck`
- `bun run lint`
- `bun test`
- `bun run build`
- `prettier --check src/utils/permit-invalidation-utils.ts tests/permit-invalidation-utils.test.ts src/hooks/use-permit-invalidation.ts src/components/permit-row.tsx src/components/dashboard-page.tsx`

Closes #455.