### PR TITLE
fix: improve Supabase database type helpers

### DIFF
--- a/serve.ts
+++ b/serve.ts
@@ -1,7 +1,14 @@
 import { serveDir, serveFile } from "jsr:@std/http/file-server";
 import { createClient } from "npm:@supabase/supabase-js@2.56.0";
 import { decodeFunctionData } from "npm:viem@2.24.1";
-import type { Database } from "./src/database.types.ts";
+import type { Database, Tables, TablesUpdate } from "./src/database.types.ts";
+
+type PermitClaimLookupRow = Pick<
+  Tables<"permits">,
+  "id" | "signature" | "transaction"
+>;
+type PermitClaimUpdatedRow = Pick<Tables<"permits">, "id" | "signature">;
+type PermitClaimUpdate = Pick<TablesUpdate<"permits">, "transaction">;
 
 // Default to the built frontend output so we don't 404 if STATIC_DIR is missing.
 const configuredStaticDir = Deno.env.get("STATIC_DIR") ?? "dist";
@@ -333,8 +340,9 @@ const handleRecordClaim = async (req: Request) => {
       normalizedSignatures,
     );
     if (selectError) throw selectError;
+    const existingRows: PermitClaimLookupRow[] = existing ?? [];
 
-    const conflicting = (existing ?? []).filter((row) =>
+    const conflicting = existingRows.filter((row) =>
       row.transaction &&
       String(row.transaction).toLowerCase() !== txHashWithPrefix
     );
@@ -347,16 +355,21 @@ const handleRecordClaim = async (req: Request) => {
       });
     }
 
+    const permitClaimUpdate: PermitClaimUpdate = {
+      transaction: txHashWithPrefix,
+    };
+
     const { data: updatedRows, error: updateError } = await supabase
       .from("permits")
-      .update({ transaction: txHashWithPrefix })
+      .update(permitClaimUpdate)
       .in("signature", normalizedSignatures)
       .is("transaction", null)
       .select("id, signature");
     if (updateError) throw updateError;
 
-    const updated = updatedRows?.length ?? 0;
-    const matched = new Set((existing ?? []).map((row) => row.signature));
+    const updatedPermitRows: PermitClaimUpdatedRow[] = updatedRows ?? [];
+    const updated = updatedPermitRows.length;
+    const matched = new Set(existingRows.map((row) => row.signature));
     const missing = normalizedSignatures.filter((sig) => !matched.has(sig));
 
     return jsonResponse(200, {

--- a/src/database.types.ts
+++ b/src/database.types.ts
@@ -1,6 +1,13 @@
-export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
+export type Json = string | number | boolean | null | {
+  [key: string]: Json | undefined;
+} | Json[];
 
 export type Database = {
+  // Allows Supabase clients to infer the PostgREST version emitted by the
+  // generated schema without widening the public schema helpers below.
+  __InternalSupabase: {
+    PostgrestVersion: "11.2.0 (c820efb)";
+  };
   public: {
     Tables: {
       access: {
@@ -807,79 +814,134 @@ export type Database = {
   };
 };
 
-type PublicSchema = Database[Extract<keyof Database, "public">];
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">;
+
+type DefaultSchema =
+  DatabaseWithoutInternals[Extract<keyof DatabaseWithoutInternals, "public">];
 
 export type Tables<
-  PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] & PublicSchema["Views"]) | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] & Database[PublicTableNameOrOptions["schema"]]["Views"])
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  } ? keyof (
+      & DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]][
+        "Tables"
+      ]
+      & DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]][
+        "Views"
+      ]
+    )
     : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] & Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+} ? (
+    & DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]][
+      "Tables"
+    ]
+    & DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]][
+      "Views"
+    ]
+  )[TableName] extends {
+    Row: infer R;
+  } ? R
+  : never
+  : DefaultSchemaTableNameOrOptions extends
+    keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] & DefaultSchema["Views"])[
+      DefaultSchemaTableNameOrOptions
+    ] extends {
       Row: infer R;
-    }
-    ? R
+    } ? R
     : never
-  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] & PublicSchema["Views"])
-    ? (PublicSchema["Tables"] & PublicSchema["Views"])[PublicTableNameOrOptions] extends {
-        Row: infer R;
-      }
-      ? R
-      : never
-    : never;
+  : never;
 
 export type TablesInsert<
-  PublicTableNameOrOptions extends keyof PublicSchema["Tables"] | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database } ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"] : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+  DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"] | {
+    schema: keyof DatabaseWithoutInternals;
+  },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  } ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]][
+      "Tables"
+    ]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+} ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]][
+    "Tables"
+  ][TableName] extends {
+    Insert: infer I;
+  } ? I
+  : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
       Insert: infer I;
-    }
-    ? I
+    } ? I
     : never
-  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
-        Insert: infer I;
-      }
-      ? I
-      : never
-    : never;
+  : never;
 
 export type TablesUpdate<
-  PublicTableNameOrOptions extends keyof PublicSchema["Tables"] | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database } ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"] : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+  DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"] | {
+    schema: keyof DatabaseWithoutInternals;
+  },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  } ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]][
+      "Tables"
+    ]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+} ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]][
+    "Tables"
+  ][TableName] extends {
+    Update: infer U;
+  } ? U
+  : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
       Update: infer U;
-    }
-    ? U
+    } ? U
     : never
-  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
-        Update: infer U;
-      }
-      ? U
-      : never
-    : never;
+  : never;
 
 export type Enums<
-  PublicEnumNameOrOptions extends keyof PublicSchema["Enums"] | { schema: keyof Database },
-  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database } ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"] : never = never,
-> = PublicEnumNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
-    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
-    : never;
+  DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"] | {
+    schema: keyof DatabaseWithoutInternals;
+  },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  } ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]][
+      "Enums"
+    ]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+} ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][
+    EnumName
+  ]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+  : never;
 
 export type CompositeTypes<
-  PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"] | { schema: keyof Database },
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof Database;
-  }
-    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    schema: keyof DatabaseWithoutInternals;
+  } ? keyof DatabaseWithoutInternals[
+      PublicCompositeTypeNameOrOptions["schema"]
+    ]["CompositeTypes"]
     : never = never,
-> = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
-    ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-    : never;
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+} ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]][
+    "CompositeTypes"
+  ][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends
+    keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+  : never;


### PR DESCRIPTION
## Summary

- Updates the generated Supabase helper types to use `DatabaseWithoutInternals` and `DefaultSchema`, matching the current generated output shape.
- Preserves the current live schema fields while adding the internal Supabase metadata needed by the helper pattern.
- Uses the generated `Tables` and `TablesUpdate` helpers in `serve.ts` for typed permit claim lookup and update rows.

## Testing

- `deno fmt --check serve.ts src/database.types.ts`
- `deno check --lock=deno.lock serve.ts`
- `deno check src/workers/permit-checker.worker.ts src/workers/permit-checker.logic.ts`

/claim #433
Closes #433