### PR TITLE
Refresh Supabase generated types for current schema

### DIFF
--- a/src/database.types.ts
+++ b/src/database.types.ts
@@ -1,66 +1,14 @@
-export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
+// This type is used internally by other exports
+type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
 
 export type Database = {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "11.2.0 (c820efb)";
+  };
   public: {
     Tables: {
-      access: {
-        Row: {
-          created: string;
-          id: number;
-          labels: Json | null;
-          location_id: number | null;
-          multiplier: number;
-          multiplier_reason: string | null;
-          repository_id: number | null;
-          updated: string | null;
-          user_id: number;
-        };
-        Insert: {
-          created?: string;
-          id?: number;
-          labels?: Json | null;
-          location_id?: number | null;
-          multiplier?: number;
-          multiplier_reason?: string | null;
-          repository_id?: number | null;
-          updated?: string | null;
-          user_id: number;
-        };
-        Update: {
-          created?: string;
-          id?: number;
-          labels?: Json | null;
-          location_id?: number | null;
-          multiplier?: number;
-          multiplier_reason?: string | null;
-          repository_id?: number | null;
-          updated?: string | null;
-          user_id?: number;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "access_user_id_fkey";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "fk_access_location";
-            columns: ["location_id"];
-            isOneToOne: false;
-            referencedRelation: "issues_view";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "fk_access_location";
-            columns: ["location_id"];
-            isOneToOne: false;
-            referencedRelation: "locations";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
       credits: {
         Row: {
           amount: number;
@@ -236,51 +184,6 @@ export type Database = {
         };
         Relationships: [];
       };
-      labels: {
-        Row: {
-          authorized: boolean | null;
-          created: string;
-          id: number;
-          label_from: string | null;
-          label_to: string | null;
-          location_id: number | null;
-          updated: string | null;
-        };
-        Insert: {
-          authorized?: boolean | null;
-          created?: string;
-          id?: number;
-          label_from?: string | null;
-          label_to?: string | null;
-          location_id?: number | null;
-          updated?: string | null;
-        };
-        Update: {
-          authorized?: boolean | null;
-          created?: string;
-          id?: number;
-          label_from?: string | null;
-          label_to?: string | null;
-          location_id?: number | null;
-          updated?: string | null;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "labels_location_id_fkey";
-            columns: ["location_id"];
-            isOneToOne: false;
-            referencedRelation: "issues_view";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "labels_location_id_fkey";
-            columns: ["location_id"];
-            isOneToOne: false;
-            referencedRelation: "locations";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
       locations: {
         Row: {
           comment_id: number | null;
@@ -322,51 +225,6 @@ export type Database = {
           user_id?: number | null;
         };
         Relationships: [];
-      };
-      logs: {
-        Row: {
-          created: string;
-          id: number;
-          level: string | null;
-          location_id: number | null;
-          log: string;
-          metadata: Json | null;
-          updated: string | null;
-        };
-        Insert: {
-          created?: string;
-          id?: number;
-          level?: string | null;
-          location_id?: number | null;
-          log: string;
-          metadata?: Json | null;
-          updated?: string | null;
-        };
-        Update: {
-          created?: string;
-          id?: number;
-          level?: string | null;
-          location_id?: number | null;
-          log?: string;
-          metadata?: Json | null;
-          updated?: string | null;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "fk_logs_location";
-            columns: ["location_id"];
-            isOneToOne: false;
-            referencedRelation: "issues_view";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "fk_logs_location";
-            columns: ["location_id"];
-            isOneToOne: false;
-            referencedRelation: "locations";
-            referencedColumns: ["id"];
-          },
-        ];
       };
       partners: {
         Row: {
@@ -426,7 +284,6 @@ export type Database = {
           partner_id: number | null;
           signature: string;
           token_id: number | null;
-          invalidation: string | null;
           transaction: string | null;
           updated: string | null;
         };
@@ -441,7 +298,6 @@ export type Database = {
           partner_id?: number | null;
           signature: string;
           token_id?: number | null;
-          invalidation?: string | null;
           transaction?: string | null;
           updated?: string | null;
         };
@@ -456,7 +312,6 @@ export type Database = {
           partner_id?: number | null;
           signature?: string;
           token_id?: number | null;
-          invalidation?: string | null;
           transaction?: string | null;
           updated?: string | null;
         };
@@ -729,9 +584,7 @@ export type Database = {
         Returns: undefined;
       };
       read_secret: {
-        Args: {
-          secret_name: string;
-        };
+        Args: { secret_name: string };
         Returns: string;
       };
     };
@@ -807,21 +660,29 @@ export type Database = {
   };
 };
 
-type PublicSchema = Database[Extract<keyof Database, "public">];
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">;
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">];
 
 export type Tables<
-  PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] & PublicSchema["Views"]) | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] & Database[PublicTableNameOrOptions["schema"]]["Views"])
+  DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] & DefaultSchema["Views"]) | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
     : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] & Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
       Row: infer R;
     }
     ? R
     : never
-  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] & PublicSchema["Views"])
-    ? (PublicSchema["Tables"] & PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] & DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
         Row: infer R;
       }
       ? R
@@ -829,16 +690,22 @@ export type Tables<
     : never;
 
 export type TablesInsert<
-  PublicTableNameOrOptions extends keyof PublicSchema["Tables"] | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database } ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"] : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+  DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"] | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Insert: infer I;
     }
     ? I
     : never
-  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
         Insert: infer I;
       }
       ? I
@@ -846,16 +713,22 @@ export type TablesInsert<
     : never;
 
 export type TablesUpdate<
-  PublicTableNameOrOptions extends keyof PublicSchema["Tables"] | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database } ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"] : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+  DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"] | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Update: infer U;
     }
     ? U
     : never
-  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
         Update: infer U;
       }
       ? U
@@ -863,23 +736,31 @@ export type TablesUpdate<
     : never;
 
 export type Enums<
-  PublicEnumNameOrOptions extends keyof PublicSchema["Enums"] | { schema: keyof Database },
-  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database } ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"] : never = never,
-> = PublicEnumNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
-    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+  DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"] | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
     : never;
 
 export type CompositeTypes<
-  PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"] | { schema: keyof Database },
+  PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"] | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof Database;
+    schema: keyof DatabaseWithoutInternals;
   }
-    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
-> = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
-    ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never;


### PR DESCRIPTION
Resolves #433.

## Changes
- Refreshes `src/database.types.ts` using the generated Supabase types from `development-broken`.
- Keeps the current `development` branch file layout while applying the regenerated schema definitions.
- Includes the generated Supabase internals metadata and removes stale table/field definitions no longer present in the generated output.

## Verification
- `bun run typecheck`
- `bun run lint`
- `bunx prettier --check src/database.types.ts`
