### PR TITLE
fix: tighten Supabase client typing

### DIFF
--- a/scripts/permit2-claim-test-permits.ts
+++ b/scripts/permit2-claim-test-permits.ts
@@ -443,7 +443,7 @@ async function loadPermits({
   beneficiary,
   since,
 }: {
-  supabase: SupabaseClient;
+  supabase: SupabaseClient<Database>;
   beneficiary: string;
   since?: string;
 }): Promise<{ permits: MappedPermit[]; skipped: { id: number; reason: string }[] }> {

--- a/src/workers/permit-checker.worker.ts
+++ b/src/workers/permit-checker.worker.ts
@@ -1,4 +1,4 @@
-import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { createRpcClient } from "@ubiquity-dao/permit2-rpc-client";
 import { type Address } from "viem";
 import { RPC_URL } from "../constants/config.ts";


### PR DESCRIPTION
## Summary
- Type the permit claim script's Supabase client as `SupabaseClient<Database>` so `fetchPermitsFromDb` keeps the generated schema through the call chain.
- Make the worker's `SupabaseClient` import type-only while preserving the existing `createClient<Database>` initialization.

## Notes
- This targets the remaining schema-awareness gap for #433 without regenerating or reshaping the already-present `database.types.ts` helpers.

Closes #433