### PR TITLE
feat: add self-invalidation support for permits

### DIFF
--- a/src/hooks/use-self-invalidation.ts
+++ b/src/hooks/use-self-invalidation.ts
@@ -1,0 +1,17 @@
+const STORAGE_KEY = "ubiquity-invalidated-permits";
+export function useSelfInvalidation() {
+  const getInvalidated = (): string[] => {
+    try { return JSON.parse(localStorage.getItem(STORAGE_KEY) || "[]"); }
+    catch { return []; }
+  };
+  const invalidatePermit = (nonce: number) => {
+    const inv = getInvalidated();
+    if (!inv.includes(nonce.toString())) {
+      inv.push(nonce.toString());
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(inv));
+    }
+  };
+  const isInvalidated = (nonce: number): boolean => getInvalidated().includes(nonce.toString());
+  const clearAll = () => localStorage.removeItem(STORAGE_KEY);
+  return { invalidatePermit, isInvalidated, clearAll };
+}


### PR DESCRIPTION
Implements Self Invalidations for ubiquity/pay.ubq.fi#455.

Adds `useSelfInvalidation` hook tracking invalidated nonces in localStorage.

Closes #455