### PR TITLE
fix: refresh Supabase database types

### DIFF
--- a/scripts/permit2-audit.ts
+++ b/scripts/permit2-audit.ts
@@ -336,7 +336,8 @@ async function buildAuditEntries(
   return draft.map((d): PermitAuditEntry => {
     const formatted = formatAmount({ chainId: d.chainId, tokenAddress: d.token, rawAmount: d.row.amount });
     const dbTx = safe0xTxHash(d.row.transaction);
-    const dbInvalidation = safe0xTxHash(d.row.invalidation ?? null);
+    // The production schema no longer stores permit invalidation tx hashes.
+    const dbInvalidation: `0x${string}` | null = null;
     const githubUrl = d.row.location?.node_url ? String(d.row.location.node_url) : null;
 
     const usedOld =
@@ -348,10 +349,8 @@ async function buildAuditEntries(
         ? getUsed({ chainId: d.chainId, permit2Address: NEW_PERMIT2_ADDRESS, owner: d.owner, wordPos: d.wordPos, bitPos: d.bitPos })
         : { used: null as boolean | null };
 
-    const adjustedExpected =
-      d.expected.kind === "old" && usedOld.used === false && usedNew.used === true
-        ? { kind: "new" as Permit2Kind, address: NEW_PERMIT2_ADDRESS }
-        : d.expected;
+    const adjustedExpected: { kind: Permit2Kind; address: `0x${string}` | null; error?: string } =
+      d.expected.kind === "old" && usedOld.used === false && usedNew.used === true ? { kind: "new" as Permit2Kind, address: NEW_PERMIT2_ADDRESS } : d.expected;
     const usedExpected = (() => {
       if (adjustedExpected.kind === "old") return usedOld.used;
       if (adjustedExpected.kind === "new") return usedNew.used;
@@ -454,9 +453,7 @@ const main = async () => {
 
   const anomalies = {
     onChainUsedButDbTransactionNull: permits.filter((p) => p.nonceUsed.expected === true && !hasDbUsage(p)),
-    dbTransactionSetButNonceUnused: permits.filter(
-      (p) => p.dbTransaction !== null && p.nonceUsed.old === false && p.nonceUsed.new === false
-    ),
+    dbTransactionSetButNonceUnused: permits.filter((p) => p.dbTransaction !== null && p.nonceUsed.old === false && p.nonceUsed.new === false),
     expectedOldButUsedNew: permits.filter((p) => p.expectedPermit2 === "old" && p.nonceUsed.old === false && p.nonceUsed.new === true),
     expectedNewButUsedOld: permits.filter((p) => p.expectedPermit2 === "new" && p.nonceUsed.new === false && p.nonceUsed.old === true),
     nonceUsedOnBothContracts: permits.filter((p) => p.nonceUsed.old === true && p.nonceUsed.new === true),

--- a/scripts/permit2-scan-invalidations.ts
+++ b/scripts/permit2-scan-invalidations.ts
@@ -1,15 +1,7 @@
 #!/usr/bin/env -S deno run -A --ext=ts --env-file=.env
 
 import { keccak256, stringToHex } from "viem";
-import {
-  createSupabaseClientFromEnv,
-  getRpcBaseUrlFromEnv,
-  isHexAddress,
-  NEW_PERMIT2_ADDRESS,
-  noncePositions,
-  normalizeHexAddress,
-  OLD_PERMIT2_ADDRESS,
-} from "./permit2-tools.ts";
+import { getRpcBaseUrlFromEnv, isHexAddress, NEW_PERMIT2_ADDRESS, noncePositions, normalizeHexAddress, OLD_PERMIT2_ADDRESS } from "./permit2-tools.ts";
 
 type CliArgs = {
   report: string;
@@ -47,7 +39,7 @@ What it does:
   - Reads a permit2 audit report (default: ${DEFAULT_REPORT}).
   - Scans Permit2 UnorderedNonceInvalidation logs for the owners in the report.
   - Matches invalidation masks to permit nonces and outputs a JSON report.
-  - Optionally writes invalidation tx hashes into Supabase permits.invalidation.
+  - Reports selected invalidation tx hashes without writing to Supabase.
 
 Options:
   -r, --report  Audit report JSON path (default: ${DEFAULT_REPORT}).
@@ -56,7 +48,7 @@ Options:
   -s, --since   Only scan logs from this timestamp (Date.parse-able).
       --until   Only scan logs up to this timestamp (Date.parse-able).
       --from-block  Start scanning from this block number (decimal or hex).
-      --execute Actually write invalidation tx hashes to Supabase (default: false).
+      --execute Request a DB write. This is now reported as unsupported because permits.invalidation was removed.
       --max-updates  Safety limit for number of permit rows to update (default: 500).
       --chunk-size   Block range size for eth_getLogs (default: 10000).
       --timeout-ms   RPC timeout in milliseconds (default: 20000; 0 disables).
@@ -337,22 +329,11 @@ const parseBlockValue = (value: string | undefined): bigint | null => {
   return null;
 };
 
-const normalizeTxHash = (value: string | null | undefined): `0x${string}` | null => {
-  if (!value) return null;
-  const trimmed = value.trim().toLowerCase();
-  if (!/^0x[0-9a-f]{64}$/.test(trimmed)) return null;
-  return trimmed as `0x${string}`;
-};
-
 let rpcTimeoutMs = 20_000;
 
 const nowIso = () => new Date().toISOString();
 
-const runWithConcurrency = async <T>(
-  items: T[],
-  concurrency: number,
-  task: (item: T, index: number) => Promise<void>
-) => {
+const runWithConcurrency = async <T>(items: T[], concurrency: number, task: (item: T, index: number) => Promise<void>) => {
   if (items.length === 0) return;
   const limit = Math.max(1, Math.floor(concurrency));
   let cursor = 0;
@@ -367,17 +348,7 @@ const runWithConcurrency = async <T>(
   await Promise.all(workers);
 };
 
-const rpcCall = async <T>({
-  rpcBaseUrl,
-  chainId,
-  method,
-  params,
-}: {
-  rpcBaseUrl: string;
-  chainId: number;
-  method: string;
-  params: unknown[];
-}): Promise<T> => {
+const rpcCall = async <T>({ rpcBaseUrl, chainId, method, params }: { rpcBaseUrl: string; chainId: number; method: string; params: unknown[] }): Promise<T> => {
   const endpoint = `${rpcBaseUrl}/${chainId}`;
   const controller = rpcTimeoutMs > 0 ? new AbortController() : null;
   const timeout = controller ? setTimeout(() => controller.abort(), rpcTimeoutMs) : null;
@@ -653,77 +624,8 @@ const pickInvalidation = ({
   return sorted[0] ?? null;
 };
 
-async function updateInvalidationsInDb({
-  supabase,
-  selected,
-  maxUpdates,
-}: {
-  supabase: ReturnType<typeof createSupabaseClientFromEnv>["client"];
-  selected: SelectedInvalidation[];
-  maxUpdates: number;
-}): Promise<{
-  updated: number;
-  conflicts: Array<{ permitId: number; existing: string; tx: string }>;
-  missing: number[];
-}> {
-  const ids = selected.map((entry) => entry.permitId);
-  if (ids.length === 0) return { updated: 0, conflicts: [], missing: [] };
-
-  const { data: existingRows, error: selectError } = await supabase.from("permits").select("id, invalidation").in("id", ids);
-  if (selectError) throw new Error(selectError.message);
-
-  const existingById = new Map<number, { invalidation: string | null }>();
-  for (const row of existingRows ?? []) {
-    const id = Number((row as { id: number }).id);
-    const invalidationRaw = (row as { invalidation?: string | null }).invalidation ?? null;
-    existingById.set(id, { invalidation: invalidationRaw ? invalidationRaw : null });
-  }
-
-  const conflicts: Array<{ permitId: number; existing: string; tx: string }> = [];
-  const missing: number[] = [];
-  const updatesByTx = new Map<string, number[]>();
-
-  for (const entry of selected) {
-    const existing = existingById.get(entry.permitId);
-    if (!existing) {
-      missing.push(entry.permitId);
-      continue;
-    }
-
-    const existingTx = normalizeTxHash(existing.invalidation);
-    const desiredTx = normalizeTxHash(entry.txHash);
-    if (!desiredTx) continue;
-
-    if (existingTx) {
-      if (existingTx !== desiredTx) {
-        conflicts.push({ permitId: entry.permitId, existing: existingTx, tx: desiredTx });
-      }
-      continue;
-    }
-
-    const list = updatesByTx.get(desiredTx) ?? [];
-    list.push(entry.permitId);
-    updatesByTx.set(desiredTx, list);
-  }
-
-  let updated = 0;
-  for (const [tx, permitIds] of updatesByTx.entries()) {
-    if (updated >= maxUpdates) break;
-    const remaining = maxUpdates - updated;
-    const chunk = permitIds.slice(0, remaining);
-    if (chunk.length === 0) continue;
-    const { data: updatedRows, error: updateError } = await supabase
-      .from("permits")
-      .update({ invalidation: tx })
-      .in("id", chunk)
-      .is("invalidation", null)
-      .select("id");
-    if (updateError) throw new Error(updateError.message);
-    updated += updatedRows?.length ?? 0;
-  }
-
-  return { updated, conflicts, missing };
-}
+const INVALIDATION_DB_WRITE_UNSUPPORTED =
+  "Supabase permits.invalidation is no longer in the generated schema; use the JSON report selectedInvalidations instead.";
 
 const loadReportPermits = (raw: string) => {
   const parsed = JSON.parse(raw) as {
@@ -772,9 +674,7 @@ const main = async () => {
   const reportRaw = await Deno.readTextFile(args.report);
   const reportPermits = loadReportPermits(reportRaw);
   log(`Report permits: ${reportPermits.length}`);
-  log(
-    `Config: chunkSize=${args.chunkSize} concurrency=${concurrency} timeoutMs=${args.timeoutMs} fromBlock=${fromBlockOverride?.toString() ?? "none"}`
-  );
+  log(`Config: chunkSize=${args.chunkSize} concurrency=${concurrency} timeoutMs=${args.timeoutMs} fromBlock=${fromBlockOverride?.toString() ?? "none"}`);
 
   const skipped: Array<{ id: number | null; reason: string }> = [];
   const permits: PermitTarget[] = [];
@@ -827,7 +727,7 @@ const main = async () => {
       githubUrl: typeof entry.githubUrl === "string" ? entry.githubUrl : null,
       beneficiary: typeof entry.beneficiary === "string" ? normalizeHexAddress(entry.beneficiary) : null,
       token: typeof entry.token === "string" ? normalizeHexAddress(entry.token) : null,
-      signature: typeof entry.signature === "string" ? entry.signature.toLowerCase() as `0x${string}` : null,
+      signature: typeof entry.signature === "string" ? (entry.signature.toLowerCase() as `0x${string}`) : null,
     });
   }
   log(`Permits scanned: ${permits.length}; skipped: ${skipped.length}`);
@@ -903,9 +803,7 @@ const main = async () => {
         useBlockscout: args.useBlockscout,
         errors,
       });
-      log(
-        `Chunk ${range.index.toString()}/${totalChunks.toString()} blocks ${range.start.toString()}..${range.end.toString()} logs=${logs.length}`
-      );
+      log(`Chunk ${range.index.toString()}/${totalChunks.toString()} blocks ${range.start.toString()}..${range.end.toString()} logs=${logs.length}`);
       for (const log of logs) {
         const parsed = parseInvalidationLog({ chainId: group.chainId, permit2Address: group.permit2Address, owner: group.owner, log });
         if (!parsed) continue;
@@ -929,7 +827,15 @@ const main = async () => {
     permit2Addresses: `0x${string}`[];
     invalidations: Array<{ txHash: `0x${string}`; blockNumber: string; permit2Address: `0x${string}`; wordPos: string; mask: string }>;
   }> = [];
-  const unmatched: Array<{ permitId: number; chainId: number; owner: `0x${string}`; nonce: string; wordPos: string; bitPos: string; permit2Addresses: `0x${string}`[] }> = [];
+  const unmatched: Array<{
+    permitId: number;
+    chainId: number;
+    owner: `0x${string}`;
+    nonce: string;
+    wordPos: string;
+    bitPos: string;
+    permit2Addresses: `0x${string}`[];
+  }> = [];
   const selectedInvalidations: SelectedInvalidation[] = [];
 
   for (const permit of permits) {
@@ -987,22 +893,10 @@ const main = async () => {
     }
   }
 
-  let updateResult: Awaited<ReturnType<typeof updateInvalidationsInDb>> | null = null;
   let updateError: string | null = null;
   if (args.execute) {
-    const { client: supabase, usesServiceRole } = createSupabaseClientFromEnv({ preferServiceRole: true });
-    if (!usesServiceRole) {
-      throw new Error("Refusing to --execute without SUPABASE_SERVICE_ROLE_KEY (service role required to bypass RLS for updates).");
-    }
-    console.error("Note: using SUPABASE_SERVICE_ROLE_KEY (bypasses RLS); results may differ from browser worker behavior.");
-    try {
-      updateResult = await updateInvalidationsInDb({ supabase, selected: selectedInvalidations, maxUpdates: args.maxUpdates });
-      log(`DB update: updated=${updateResult.updated} conflicts=${updateResult.conflicts.length} missing=${updateResult.missing.length}`);
-    } catch (error) {
-      updateError = error instanceof Error ? error.message : String(error);
-      updateResult = null;
-      log(`DB update error: ${updateError}`);
-    }
+    updateError = INVALIDATION_DB_WRITE_UNSUPPORTED;
+    log(`DB update skipped: ${updateError}`);
   }
 
   const report = {
@@ -1033,8 +927,8 @@ const main = async () => {
     selectedInvalidations,
     errors,
     ...(args.execute
-      ? { executed: true, updated: updateResult?.updated ?? 0, conflicts: updateResult?.conflicts ?? [], missing: updateResult?.missing ?? [], updateError }
-      : { executed: false }),
+      ? { executeRequested: true, executed: false, updated: 0, conflicts: [], missing: [], updateError }
+      : { executeRequested: false, executed: false }),
   };
 
   const output = stringifyJson(report, args.pretty);

--- a/scripts/permit2-tools.ts
+++ b/scripts/permit2-tools.ts
@@ -67,11 +67,7 @@ type JsonRpcResponse = {
 
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
-const runWithConcurrency = async <T>(
-  items: T[],
-  concurrency: number,
-  task: (item: T, index: number) => Promise<void>
-) => {
+const runWithConcurrency = async <T>(items: T[], concurrency: number, task: (item: T, index: number) => Promise<void>) => {
   if (items.length === 0) return;
   const limit = Math.max(1, Math.floor(concurrency));
   let cursor = 0;
@@ -141,7 +137,6 @@ export async function fetchPermitsFromDb({
     deadline,
     signature,
     transaction,
-    invalidation,
     created,
     beneficiary_id,
     location_id,

--- a/serve.ts
+++ b/serve.ts
@@ -1,36 +1,29 @@
 import { serveDir, serveFile } from "jsr:@std/http/file-server";
 import { createClient } from "npm:@supabase/supabase-js@2.56.0";
 import { decodeFunctionData } from "npm:viem@2.24.1";
-import type { Database } from "./src/database.types.ts";
+import type { Database, Tables, TablesUpdate } from "./src/database.types.ts";
+
+type PermitClaimLookupRow = Pick<Tables<"permits">, "id" | "signature" | "transaction">;
+type PermitClaimUpdatedRow = Pick<Tables<"permits">, "id" | "signature">;
+type PermitClaimUpdate = Pick<TablesUpdate<"permits">, "transaction">;
 
 // Default to the built frontend output so we don't 404 if STATIC_DIR is missing.
 const configuredStaticDir = Deno.env.get("STATIC_DIR") ?? "dist";
 const normalizeRoot = (value: string) => value.replace(/\/+$/, "");
-const joinRoot = (base: string, child: string) =>
-  `${base.replace(/\/+$/, "")}/${child.replace(/^\/+/, "")}`;
+const joinRoot = (base: string, child: string) => `${base.replace(/\/+$/, "")}/${child.replace(/^\/+/, "")}`;
 const moduleRelativeRoot = (() => {
   if (configuredStaticDir.startsWith("/")) {
     return null;
   }
   const moduleUrl = new URL(import.meta.url);
-  return moduleUrl.protocol === "file:"
-    ? normalizeRoot(
-      decodeURIComponent(
-        new URL(`${configuredStaticDir}/`, moduleUrl).pathname,
-      ),
-    )
-    : null;
+  return moduleUrl.protocol === "file:" ? normalizeRoot(decodeURIComponent(new URL(`${configuredStaticDir}/`, moduleUrl).pathname)) : null;
 })();
 const staticRoots = Array.from(
   new Set(
-    [
-      configuredStaticDir,
-      configuredStaticDir.startsWith("/")
-        ? null
-        : joinRoot(Deno.cwd(), configuredStaticDir),
-      moduleRelativeRoot,
-    ].filter((value): value is string => Boolean(value)).map(normalizeRoot),
-  ),
+    [configuredStaticDir, configuredStaticDir.startsWith("/") ? null : joinRoot(Deno.cwd(), configuredStaticDir), moduleRelativeRoot]
+      .filter((value): value is string => Boolean(value))
+      .map(normalizeRoot)
+  )
 );
 
 const supabaseUrl = Deno.env.get("SUPABASE_URL");
@@ -41,16 +34,11 @@ if (!supabaseUrl || !supabaseKey) {
   console.warn("[serve] Supabase env missing; permit claim API disabled.");
 }
 
-const supabase = supabaseUrl && supabaseKey
-  ? createClient<Database>(supabaseUrl, supabaseKey)
-  : null;
+const supabase = supabaseUrl && supabaseKey ? createClient<Database>(supabaseUrl, supabaseKey) : null;
 
 const OLD_PERMIT2_ADDRESS = "0x000000000022D473030F116dDEE9F6B43aC78BA3";
 const NEW_PERMIT2_ADDRESS = "0xd635918A75356D133d5840eE5c9ED070302C9C60";
-const PERMIT2_ADDRESSES = new Set([
-  OLD_PERMIT2_ADDRESS.toLowerCase(),
-  NEW_PERMIT2_ADDRESS.toLowerCase(),
-]);
+const PERMIT2_ADDRESSES = new Set([OLD_PERMIT2_ADDRESS.toLowerCase(), NEW_PERMIT2_ADDRESS.toLowerCase()]);
 
 const permit2DecodeAbi = [
   {
@@ -163,19 +151,15 @@ const jsonResponse = (status: number, body: unknown) =>
     headers: { "Content-Type": "application/json" },
   });
 
-const normalizeHexLowerNo0x = (value: string) =>
-  value.trim().toLowerCase().replace(/^0x/, "");
+const normalizeHexLowerNo0x = (value: string) => value.trim().toLowerCase().replace(/^0x/, "");
 
-const isValidTxHash = (value: string) =>
-  /^[0-9a-f]{64}$/.test(normalizeHexLowerNo0x(value));
+const isValidTxHash = (value: string) => /^[0-9a-f]{64}$/.test(normalizeHexLowerNo0x(value));
 
-const isValidAddress = (value: string) =>
-  /^[0-9a-f]{40}$/.test(normalizeHexLowerNo0x(value));
+const isValidAddress = (value: string) => /^[0-9a-f]{40}$/.test(normalizeHexLowerNo0x(value));
 
 const isValidPermitSignatureHex = (value: string) => {
   const normalized = normalizeHexLowerNo0x(value);
-  return /^[0-9a-f]+$/.test(normalized) &&
-    (normalized.length === 128 || normalized.length === 130);
+  return /^[0-9a-f]+$/.test(normalized) && (normalized.length === 128 || normalized.length === 130);
 };
 
 const to0xLower = (value: string) => `0x${normalizeHexLowerNo0x(value)}`;
@@ -220,28 +204,19 @@ const handleRecordClaim = async (req: Request) => {
       signature?: string;
     };
 
-    const parsedChainId = typeof networkId === "string"
-      ? Number.parseInt(networkId, 10)
-      : networkId;
-    if (
-      typeof parsedChainId !== "number" ||
-      !Number.isSafeInteger(parsedChainId) || parsedChainId <= 0
-    ) {
+    const parsedChainId = typeof networkId === "string" ? Number.parseInt(networkId, 10) : networkId;
+    if (typeof parsedChainId !== "number" || !Number.isSafeInteger(parsedChainId) || parsedChainId <= 0) {
       return jsonResponse(400, { error: "Invalid networkId" });
     }
     const chainId = parsedChainId;
 
-    if (
-      typeof transactionHash !== "string" || !isValidTxHash(transactionHash)
-    ) {
+    if (typeof transactionHash !== "string" || !isValidTxHash(transactionHash)) {
       return jsonResponse(400, { error: "Invalid transactionHash" });
     }
 
     const txHashWithPrefix = to0xLower(transactionHash);
 
-    const tx = (await rpcCall(chainId, "eth_getTransactionByHash", [
-      txHashWithPrefix,
-    ])) as {
+    const tx = (await rpcCall(chainId, "eth_getTransactionByHash", [txHashWithPrefix])) as {
       input?: string;
       blockHash?: string | null;
       to?: string | null;
@@ -254,16 +229,11 @@ const handleRecordClaim = async (req: Request) => {
       return jsonResponse(400, { error: "Transaction not mined yet" });
     }
 
-    if (
-      typeof tx.to !== "string" || !isValidAddress(tx.to) ||
-      !PERMIT2_ADDRESSES.has(tx.to.toLowerCase())
-    ) {
+    if (typeof tx.to !== "string" || !isValidAddress(tx.to) || !PERMIT2_ADDRESSES.has(tx.to.toLowerCase())) {
       return jsonResponse(400, { error: "Transaction is not a Permit2 call" });
     }
 
-    const receipt = (await rpcCall(chainId, "eth_getTransactionReceipt", [
-      txHashWithPrefix,
-    ])) as { status?: string } | null;
+    const receipt = (await rpcCall(chainId, "eth_getTransactionReceipt", [txHashWithPrefix])) as { status?: string } | null;
     if (!receipt) {
       return jsonResponse(400, { error: "Transaction receipt unavailable" });
     }
@@ -293,10 +263,7 @@ const handleRecordClaim = async (req: Request) => {
         extractedSignatures = [signature];
       } else if (decoded.functionName === "batchPermitTransferFrom") {
         const signatures = args.at(-1);
-        if (
-          !Array.isArray(signatures) ||
-          !signatures.every((s) => typeof s === "string")
-        ) {
+        if (!Array.isArray(signatures) || !signatures.every((s) => typeof s === "string")) {
           return jsonResponse(400, {
             error: "Failed to extract Permit2 signatures",
           });
@@ -312,9 +279,7 @@ const handleRecordClaim = async (req: Request) => {
       return jsonResponse(400, { error: "Unable to decode Permit2 calldata" });
     }
 
-    const normalizedSignatures = Array.from(
-      new Set(extractedSignatures.map(to0xLower)),
-    );
+    const normalizedSignatures = Array.from(new Set(extractedSignatures.map(to0xLower)));
     if (!normalizedSignatures.length) {
       return jsonResponse(400, {
         error: "No signatures found in transaction input",
@@ -326,37 +291,34 @@ const handleRecordClaim = async (req: Request) => {
       });
     }
 
-    const { data: existing, error: selectError } = await supabase.from(
-      "permits",
-    ).select("id, signature, transaction").in(
-      "signature",
-      normalizedSignatures,
-    );
+    const { data: existing, error: selectError } = await supabase.from("permits").select("id, signature, transaction").in("signature", normalizedSignatures);
     if (selectError) throw selectError;
+    const existingRows: PermitClaimLookupRow[] = existing ?? [];
 
-    const conflicting = (existing ?? []).filter((row) =>
-      row.transaction &&
-      String(row.transaction).toLowerCase() !== txHashWithPrefix
-    );
+    const conflicting = existingRows.filter((row) => row.transaction && String(row.transaction).toLowerCase() !== txHashWithPrefix);
     if (conflicting.length > 0) {
       return jsonResponse(409, {
         success: false,
-        error:
-          "One or more permits already have a different recorded transaction",
+        error: "One or more permits already have a different recorded transaction",
         conflicts: conflicting.map((row) => row.signature),
       });
     }
 
+    const permitClaimUpdate: PermitClaimUpdate = {
+      transaction: txHashWithPrefix,
+    };
+
     const { data: updatedRows, error: updateError } = await supabase
       .from("permits")
-      .update({ transaction: txHashWithPrefix })
+      .update(permitClaimUpdate)
       .in("signature", normalizedSignatures)
       .is("transaction", null)
       .select("id, signature");
     if (updateError) throw updateError;
 
-    const updated = updatedRows?.length ?? 0;
-    const matched = new Set((existing ?? []).map((row) => row.signature));
+    const updatedPermitRows: PermitClaimUpdatedRow[] = updatedRows ?? [];
+    const updated = updatedPermitRows.length;
+    const matched = new Set(existingRows.map((row) => row.signature));
     const missing = normalizedSignatures.filter((sig) => !matched.has(sig));
 
     return jsonResponse(200, {
@@ -384,9 +346,7 @@ const handleRequest = async (req: Request) => {
   }
 
   const isHead = req.method === "HEAD";
-  const request = isHead
-    ? new Request(req.url, { method: "GET", headers: req.headers })
-    : req;
+  const request = isHead ? new Request(req.url, { method: "GET", headers: req.headers }) : req;
 
   // Try to serve the file directly (HEAD is coerced to GET to avoid 405s on probes)
   let response: Response | null = null;

--- a/src/database.types.ts
+++ b/src/database.types.ts
@@ -1,66 +1,11 @@
 export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
 
 export type Database = {
+  __InternalSupabase: {
+    PostgrestVersion: "11.2.0 (c820efb)";
+  };
   public: {
     Tables: {
-      access: {
-        Row: {
-          created: string;
-          id: number;
-          labels: Json | null;
-          location_id: number | null;
-          multiplier: number;
-          multiplier_reason: string | null;
-          repository_id: number | null;
-          updated: string | null;
-          user_id: number;
-        };
-        Insert: {
-          created?: string;
-          id?: number;
-          labels?: Json | null;
-          location_id?: number | null;
-          multiplier?: number;
-          multiplier_reason?: string | null;
-          repository_id?: number | null;
-          updated?: string | null;
-          user_id: number;
-        };
-        Update: {
-          created?: string;
-          id?: number;
-          labels?: Json | null;
-          location_id?: number | null;
-          multiplier?: number;
-          multiplier_reason?: string | null;
-          repository_id?: number | null;
-          updated?: string | null;
-          user_id?: number;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "access_user_id_fkey";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "fk_access_location";
-            columns: ["location_id"];
-            isOneToOne: false;
-            referencedRelation: "issues_view";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "fk_access_location";
-            columns: ["location_id"];
-            isOneToOne: false;
-            referencedRelation: "locations";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
       credits: {
         Row: {
           amount: number;
@@ -236,51 +181,6 @@ export type Database = {
         };
         Relationships: [];
       };
-      labels: {
-        Row: {
-          authorized: boolean | null;
-          created: string;
-          id: number;
-          label_from: string | null;
-          label_to: string | null;
-          location_id: number | null;
-          updated: string | null;
-        };
-        Insert: {
-          authorized?: boolean | null;
-          created?: string;
-          id?: number;
-          label_from?: string | null;
-          label_to?: string | null;
-          location_id?: number | null;
-          updated?: string | null;
-        };
-        Update: {
-          authorized?: boolean | null;
-          created?: string;
-          id?: number;
-          label_from?: string | null;
-          label_to?: string | null;
-          location_id?: number | null;
-          updated?: string | null;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "labels_location_id_fkey";
-            columns: ["location_id"];
-            isOneToOne: false;
-            referencedRelation: "issues_view";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "labels_location_id_fkey";
-            columns: ["location_id"];
-            isOneToOne: false;
-            referencedRelation: "locations";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
       locations: {
         Row: {
           comment_id: number | null;
@@ -322,51 +222,6 @@ export type Database = {
           user_id?: number | null;
         };
         Relationships: [];
-      };
-      logs: {
-        Row: {
-          created: string;
-          id: number;
-          level: string | null;
-          location_id: number | null;
-          log: string;
-          metadata: Json | null;
-          updated: string | null;
-        };
-        Insert: {
-          created?: string;
-          id?: number;
-          level?: string | null;
-          location_id?: number | null;
-          log: string;
-          metadata?: Json | null;
-          updated?: string | null;
-        };
-        Update: {
-          created?: string;
-          id?: number;
-          level?: string | null;
-          location_id?: number | null;
-          log?: string;
-          metadata?: Json | null;
-          updated?: string | null;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "fk_logs_location";
-            columns: ["location_id"];
-            isOneToOne: false;
-            referencedRelation: "issues_view";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "fk_logs_location";
-            columns: ["location_id"];
-            isOneToOne: false;
-            referencedRelation: "locations";
-            referencedColumns: ["id"];
-          },
-        ];
       };
       partners: {
         Row: {
@@ -426,7 +281,6 @@ export type Database = {
           partner_id: number | null;
           signature: string;
           token_id: number | null;
-          invalidation: string | null;
           transaction: string | null;
           updated: string | null;
         };
@@ -441,7 +295,6 @@ export type Database = {
           partner_id?: number | null;
           signature: string;
           token_id?: number | null;
-          invalidation?: string | null;
           transaction?: string | null;
           updated?: string | null;
         };
@@ -456,7 +309,6 @@ export type Database = {
           partner_id?: number | null;
           signature?: string;
           token_id?: number | null;
-          invalidation?: string | null;
           transaction?: string | null;
           updated?: string | null;
         };
@@ -807,15 +659,18 @@ export type Database = {
   };
 };
 
-type PublicSchema = Database[Extract<keyof Database, "public">];
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">;
+
+type PublicSchema = DatabaseWithoutInternals[Extract<keyof DatabaseWithoutInternals, "public">];
 
 export type Tables<
-  PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] & PublicSchema["Views"]) | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] & Database[PublicTableNameOrOptions["schema"]]["Views"])
+  PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] & PublicSchema["Views"]) | { schema: keyof DatabaseWithoutInternals },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof DatabaseWithoutInternals }
+    ? keyof (DatabaseWithoutInternals[PublicTableNameOrOptions["schema"]]["Tables"] & DatabaseWithoutInternals[PublicTableNameOrOptions["schema"]]["Views"])
     : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] & Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+> = PublicTableNameOrOptions extends { schema: keyof DatabaseWithoutInternals }
+  ? (DatabaseWithoutInternals[PublicTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
       Row: infer R;
     }
     ? R
@@ -829,10 +684,12 @@ export type Tables<
     : never;
 
 export type TablesInsert<
-  PublicTableNameOrOptions extends keyof PublicSchema["Tables"] | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database } ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"] : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+  PublicTableNameOrOptions extends keyof PublicSchema["Tables"] | { schema: keyof DatabaseWithoutInternals },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof DatabaseWithoutInternals }
+    ? keyof DatabaseWithoutInternals[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof DatabaseWithoutInternals }
+  ? DatabaseWithoutInternals[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Insert: infer I;
     }
     ? I
@@ -846,10 +703,12 @@ export type TablesInsert<
     : never;
 
 export type TablesUpdate<
-  PublicTableNameOrOptions extends keyof PublicSchema["Tables"] | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database } ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"] : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+  PublicTableNameOrOptions extends keyof PublicSchema["Tables"] | { schema: keyof DatabaseWithoutInternals },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof DatabaseWithoutInternals }
+    ? keyof DatabaseWithoutInternals[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof DatabaseWithoutInternals }
+  ? DatabaseWithoutInternals[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Update: infer U;
     }
     ? U
@@ -863,23 +722,25 @@ export type TablesUpdate<
     : never;
 
 export type Enums<
-  PublicEnumNameOrOptions extends keyof PublicSchema["Enums"] | { schema: keyof Database },
-  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database } ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"] : never = never,
-> = PublicEnumNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  PublicEnumNameOrOptions extends keyof PublicSchema["Enums"] | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends PublicEnumNameOrOptions extends { schema: keyof DatabaseWithoutInternals }
+    ? keyof DatabaseWithoutInternals[PublicEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = PublicEnumNameOrOptions extends { schema: keyof DatabaseWithoutInternals }
+  ? DatabaseWithoutInternals[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
   : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
     ? PublicSchema["Enums"][PublicEnumNameOrOptions]
     : never;
 
 export type CompositeTypes<
-  PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"] | { schema: keyof Database },
+  PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"] | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof Database;
+    schema: keyof DatabaseWithoutInternals;
   }
-    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
-> = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+> = PublicCompositeTypeNameOrOptions extends { schema: keyof DatabaseWithoutInternals }
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
   : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
     ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never;


### PR DESCRIPTION
Resolves #433.

## Summary

- refreshes the generated Supabase database types to match the current schema
- removes stale typed references to removed tables and `permits.invalidation`
- keeps helper types compatible with the generated internal metadata
- updates Permit2 scripts and server paths so they compile against the refreshed schema

## Verification

- `npm run typecheck`
- `npm run lint`
- `npx prettier --check src/database.types.ts serve.ts scripts/permit2-tools.ts scripts/permit2-audit.ts scripts/permit2-scan-invalidations.ts`
- `npm run build`
- `npx --yes deno check --lock=deno.lock serve.ts`
- `npx --yes deno check --lock=deno.lock scripts/permit2-tools.ts scripts/permit2-audit.ts scripts/permit2-scan-invalidations.ts`
- `git diff --check`
