### PR TITLE
fix: update database types and improve type safety (#433)

### DIFF
--- a/scripts/permit2-audit.ts
+++ b/scripts/permit2-audit.ts
@@ -166,7 +166,6 @@ type PermitAuditEntry = {
   wordPos: string | null;
   bitPos: string | null;
   dbTransaction: `0x${string}` | null;
-  dbInvalidation: `0x${string}` | null;
   expectedPermit2: Permit2Kind;
   expectedPermit2Address: `0x${string}` | null;
   nonceUsed: {
@@ -336,7 +335,6 @@ async function buildAuditEntries(
   return draft.map((d): PermitAuditEntry => {
     const formatted = formatAmount({ chainId: d.chainId, tokenAddress: d.token, rawAmount: d.row.amount });
     const dbTx = safe0xTxHash(d.row.transaction);
-    const dbInvalidation = safe0xTxHash(d.row.invalidation ?? null);
     const githubUrl = d.row.location?.node_url ? String(d.row.location.node_url) : null;
 
     const usedOld =
@@ -348,7 +346,7 @@ async function buildAuditEntries(
         ? getUsed({ chainId: d.chainId, permit2Address: NEW_PERMIT2_ADDRESS, owner: d.owner, wordPos: d.wordPos, bitPos: d.bitPos })
         : { used: null as boolean | null };
 
-    const adjustedExpected =
+    const adjustedExpected: { kind: Permit2Kind; address: `0x${string}` | null; error?: string } =
       d.expected.kind === "old" && usedOld.used === false && usedNew.used === true
         ? { kind: "new" as Permit2Kind, address: NEW_PERMIT2_ADDRESS }
         : d.expected;
@@ -374,7 +372,6 @@ async function buildAuditEntries(
       wordPos: d.wordPos !== null ? d.wordPos.toString() : null,
       bitPos: d.bitPos !== null ? d.bitPos.toString() : null,
       dbTransaction: dbTx,
-      dbInvalidation,
       expectedPermit2: adjustedExpected.kind,
       expectedPermit2Address: adjustedExpected.address,
       nonceUsed: { old: usedOld.used, new: usedNew.used, expected: usedExpected },
@@ -443,14 +440,12 @@ const main = async () => {
     expectedUnknown: permits.filter((p) => p.expectedPermit2 === "unknown").length,
     dbTransactionSet: permits.filter((p) => p.dbTransaction !== null).length,
     dbTransactionNull: permits.filter((p) => p.dbTransaction === null).length,
-    dbInvalidationSet: permits.filter((p) => p.dbInvalidation !== null).length,
-    dbInvalidationNull: permits.filter((p) => p.dbInvalidation === null).length,
     nonceUsedExpectedTrue: permits.filter((p) => p.nonceUsed.expected === true).length,
     nonceUsedExpectedFalse: permits.filter((p) => p.nonceUsed.expected === false).length,
     nonceUsedExpectedNull: permits.filter((p) => p.nonceUsed.expected === null).length,
   };
 
-  const hasDbUsage = (permit: PermitAuditEntry) => permit.dbTransaction !== null || permit.dbInvalidation !== null;
+  const hasDbUsage = (permit: PermitAuditEntry) => permit.dbTransaction !== null;
 
   const anomalies = {
     onChainUsedButDbTransactionNull: permits.filter((p) => p.nonceUsed.expected === true && !hasDbUsage(p)),

--- a/scripts/permit2-scan-invalidations.ts
+++ b/scripts/permit2-scan-invalidations.ts
@@ -1,15 +1,7 @@
 #!/usr/bin/env -S deno run -A --ext=ts --env-file=.env
 
 import { keccak256, stringToHex } from "viem";
-import {
-  createSupabaseClientFromEnv,
-  getRpcBaseUrlFromEnv,
-  isHexAddress,
-  NEW_PERMIT2_ADDRESS,
-  noncePositions,
-  normalizeHexAddress,
-  OLD_PERMIT2_ADDRESS,
-} from "./permit2-tools.ts";
+import { getRpcBaseUrlFromEnv, isHexAddress, NEW_PERMIT2_ADDRESS, noncePositions, normalizeHexAddress, OLD_PERMIT2_ADDRESS } from "./permit2-tools.ts";
 
 type CliArgs = {
   report: string;
@@ -22,8 +14,6 @@ type CliArgs = {
   chunkSize: number;
   useBlockscout: boolean;
   verbose: boolean;
-  execute: boolean;
-  maxUpdates: number;
   concurrency: number;
   pretty: boolean;
   help: boolean;
@@ -40,14 +30,13 @@ const printUsage = () => {
     `
 Usage:
   deno run -A --env-file=.env scripts/permit2-scan-invalidations.ts [--report <file>] [--out <file>]
-    [--owner 0x...] [--since <timestamp>] [--until <timestamp>] [--pretty] [--execute] [--max-updates <n>]
+    [--owner 0x...] [--since <timestamp>] [--until <timestamp>] [--pretty]
     [--from-block <n>] [--chunk-size <n>] [--timeout-ms <n>] [--use-blockscout] [--verbose] [--concurrency <n>]
 
 What it does:
   - Reads a permit2 audit report (default: ${DEFAULT_REPORT}).
   - Scans Permit2 UnorderedNonceInvalidation logs for the owners in the report.
   - Matches invalidation masks to permit nonces and outputs a JSON report.
-  - Optionally writes invalidation tx hashes into Supabase permits.invalidation.
 
 Options:
   -r, --report  Audit report JSON path (default: ${DEFAULT_REPORT}).
@@ -56,8 +45,6 @@ Options:
   -s, --since   Only scan logs from this timestamp (Date.parse-able).
       --until   Only scan logs up to this timestamp (Date.parse-able).
       --from-block  Start scanning from this block number (decimal or hex).
-      --execute Actually write invalidation tx hashes to Supabase (default: false).
-      --max-updates  Safety limit for number of permit rows to update (default: 500).
       --chunk-size   Block range size for eth_getLogs (default: 10000).
       --timeout-ms   RPC timeout in milliseconds (default: 20000; 0 disables).
       --use-blockscout  Use Blockscout logs API for chain 100 (default: false).
@@ -78,8 +65,6 @@ const parseArgs = (argv: string[]): CliArgs => {
     out: DEFAULT_OUT,
     pretty: false,
     help: false,
-    execute: false,
-    maxUpdates: 500,
     timeoutMs: 20_000,
     chunkSize: 10_000,
     useBlockscout: false,
@@ -99,10 +84,6 @@ const parseArgs = (argv: string[]): CliArgs => {
     }
     if (arg === "--pretty" || arg === "-p") {
       out.pretty = true;
-      continue;
-    }
-    if (arg === "--execute") {
-      out.execute = true;
       continue;
     }
     if (arg === "--report" || arg === "-r") {
@@ -157,19 +138,6 @@ const parseArgs = (argv: string[]): CliArgs => {
     }
     if (arg.startsWith("--until=")) {
       out.until = arg.slice("--until=".length);
-      continue;
-    }
-    if (arg === "--max-updates") {
-      const v = Number(takeValue(arg, argv[i + 1]));
-      i += 1;
-      if (!Number.isFinite(v) || v <= 0) throw new Error(`Invalid --max-updates: ${argv[i]}`);
-      out.maxUpdates = Math.floor(v);
-      continue;
-    }
-    if (arg.startsWith("--max-updates=")) {
-      const v = Number(arg.slice("--max-updates=".length));
-      if (!Number.isFinite(v) || v <= 0) throw new Error(`Invalid --max-updates: ${v}`);
-      out.maxUpdates = Math.floor(v);
       continue;
     }
     if (arg === "--timeout-ms") {
@@ -337,22 +305,11 @@ const parseBlockValue = (value: string | undefined): bigint | null => {
   return null;
 };
 
-const normalizeTxHash = (value: string | null | undefined): `0x${string}` | null => {
-  if (!value) return null;
-  const trimmed = value.trim().toLowerCase();
-  if (!/^0x[0-9a-f]{64}$/.test(trimmed)) return null;
-  return trimmed as `0x${string}`;
-};
-
 let rpcTimeoutMs = 20_000;
 
 const nowIso = () => new Date().toISOString();
 
-const runWithConcurrency = async <T>(
-  items: T[],
-  concurrency: number,
-  task: (item: T, index: number) => Promise<void>
-) => {
+const runWithConcurrency = async <T>(items: T[], concurrency: number, task: (item: T, index: number) => Promise<void>) => {
   if (items.length === 0) return;
   const limit = Math.max(1, Math.floor(concurrency));
   let cursor = 0;
@@ -367,17 +324,7 @@ const runWithConcurrency = async <T>(
   await Promise.all(workers);
 };
 
-const rpcCall = async <T>({
-  rpcBaseUrl,
-  chainId,
-  method,
-  params,
-}: {
-  rpcBaseUrl: string;
-  chainId: number;
-  method: string;
-  params: unknown[];
-}): Promise<T> => {
+const rpcCall = async <T>({ rpcBaseUrl, chainId, method, params }: { rpcBaseUrl: string; chainId: number; method: string; params: unknown[] }): Promise<T> => {
   const endpoint = `${rpcBaseUrl}/${chainId}`;
   const controller = rpcTimeoutMs > 0 ? new AbortController() : null;
   const timeout = controller ? setTimeout(() => controller.abort(), rpcTimeoutMs) : null;
@@ -653,78 +600,6 @@ const pickInvalidation = ({
   return sorted[0] ?? null;
 };
 
-async function updateInvalidationsInDb({
-  supabase,
-  selected,
-  maxUpdates,
-}: {
-  supabase: ReturnType<typeof createSupabaseClientFromEnv>["client"];
-  selected: SelectedInvalidation[];
-  maxUpdates: number;
-}): Promise<{
-  updated: number;
-  conflicts: Array<{ permitId: number; existing: string; tx: string }>;
-  missing: number[];
-}> {
-  const ids = selected.map((entry) => entry.permitId);
-  if (ids.length === 0) return { updated: 0, conflicts: [], missing: [] };
-
-  const { data: existingRows, error: selectError } = await supabase.from("permits").select("id, invalidation").in("id", ids);
-  if (selectError) throw new Error(selectError.message);
-
-  const existingById = new Map<number, { invalidation: string | null }>();
-  for (const row of existingRows ?? []) {
-    const id = Number((row as { id: number }).id);
-    const invalidationRaw = (row as { invalidation?: string | null }).invalidation ?? null;
-    existingById.set(id, { invalidation: invalidationRaw ? invalidationRaw : null });
-  }
-
-  const conflicts: Array<{ permitId: number; existing: string; tx: string }> = [];
-  const missing: number[] = [];
-  const updatesByTx = new Map<string, number[]>();
-
-  for (const entry of selected) {
-    const existing = existingById.get(entry.permitId);
-    if (!existing) {
-      missing.push(entry.permitId);
-      continue;
-    }
-
-    const existingTx = normalizeTxHash(existing.invalidation);
-    const desiredTx = normalizeTxHash(entry.txHash);
-    if (!desiredTx) continue;
-
-    if (existingTx) {
-      if (existingTx !== desiredTx) {
-        conflicts.push({ permitId: entry.permitId, existing: existingTx, tx: desiredTx });
-      }
-      continue;
-    }
-
-    const list = updatesByTx.get(desiredTx) ?? [];
-    list.push(entry.permitId);
-    updatesByTx.set(desiredTx, list);
-  }
-
-  let updated = 0;
-  for (const [tx, permitIds] of updatesByTx.entries()) {
-    if (updated >= maxUpdates) break;
-    const remaining = maxUpdates - updated;
-    const chunk = permitIds.slice(0, remaining);
-    if (chunk.length === 0) continue;
-    const { data: updatedRows, error: updateError } = await supabase
-      .from("permits")
-      .update({ invalidation: tx })
-      .in("id", chunk)
-      .is("invalidation", null)
-      .select("id");
-    if (updateError) throw new Error(updateError.message);
-    updated += updatedRows?.length ?? 0;
-  }
-
-  return { updated, conflicts, missing };
-}
-
 const loadReportPermits = (raw: string) => {
   const parsed = JSON.parse(raw) as {
     anomalies?: { onChainUsedButDbTransactionNull?: { permits?: unknown[] } };
@@ -772,9 +647,7 @@ const main = async () => {
   const reportRaw = await Deno.readTextFile(args.report);
   const reportPermits = loadReportPermits(reportRaw);
   log(`Report permits: ${reportPermits.length}`);
-  log(
-    `Config: chunkSize=${args.chunkSize} concurrency=${concurrency} timeoutMs=${args.timeoutMs} fromBlock=${fromBlockOverride?.toString() ?? "none"}`
-  );
+  log(`Config: chunkSize=${args.chunkSize} concurrency=${concurrency} timeoutMs=${args.timeoutMs} fromBlock=${fromBlockOverride?.toString() ?? "none"}`);
 
   const skipped: Array<{ id: number | null; reason: string }> = [];
   const permits: PermitTarget[] = [];
@@ -827,7 +700,7 @@ const main = async () => {
       githubUrl: typeof entry.githubUrl === "string" ? entry.githubUrl : null,
       beneficiary: typeof entry.beneficiary === "string" ? normalizeHexAddress(entry.beneficiary) : null,
       token: typeof entry.token === "string" ? normalizeHexAddress(entry.token) : null,
-      signature: typeof entry.signature === "string" ? entry.signature.toLowerCase() as `0x${string}` : null,
+      signature: typeof entry.signature === "string" ? (entry.signature.toLowerCase() as `0x${string}`) : null,
     });
   }
   log(`Permits scanned: ${permits.length}; skipped: ${skipped.length}`);
@@ -903,9 +776,7 @@ const main = async () => {
         useBlockscout: args.useBlockscout,
         errors,
       });
-      log(
-        `Chunk ${range.index.toString()}/${totalChunks.toString()} blocks ${range.start.toString()}..${range.end.toString()} logs=${logs.length}`
-      );
+      log(`Chunk ${range.index.toString()}/${totalChunks.toString()} blocks ${range.start.toString()}..${range.end.toString()} logs=${logs.length}`);
       for (const log of logs) {
         const parsed = parseInvalidationLog({ chainId: group.chainId, permit2Address: group.permit2Address, owner: group.owner, log });
         if (!parsed) continue;
@@ -929,7 +800,15 @@ const main = async () => {
     permit2Addresses: `0x${string}`[];
     invalidations: Array<{ txHash: `0x${string}`; blockNumber: string; permit2Address: `0x${string}`; wordPos: string; mask: string }>;
   }> = [];
-  const unmatched: Array<{ permitId: number; chainId: number; owner: `0x${string}`; nonce: string; wordPos: string; bitPos: string; permit2Addresses: `0x${string}`[] }> = [];
+  const unmatched: Array<{
+    permitId: number;
+    chainId: number;
+    owner: `0x${string}`;
+    nonce: string;
+    wordPos: string;
+    bitPos: string;
+    permit2Addresses: `0x${string}`[];
+  }> = [];
   const selectedInvalidations: SelectedInvalidation[] = [];
 
   for (const permit of permits) {
@@ -987,24 +866,6 @@ const main = async () => {
     }
   }
 
-  let updateResult: Awaited<ReturnType<typeof updateInvalidationsInDb>> | null = null;
-  let updateError: string | null = null;
-  if (args.execute) {
-    const { client: supabase, usesServiceRole } = createSupabaseClientFromEnv({ preferServiceRole: true });
-    if (!usesServiceRole) {
-      throw new Error("Refusing to --execute without SUPABASE_SERVICE_ROLE_KEY (service role required to bypass RLS for updates).");
-    }
-    console.error("Note: using SUPABASE_SERVICE_ROLE_KEY (bypasses RLS); results may differ from browser worker behavior.");
-    try {
-      updateResult = await updateInvalidationsInDb({ supabase, selected: selectedInvalidations, maxUpdates: args.maxUpdates });
-      log(`DB update: updated=${updateResult.updated} conflicts=${updateResult.conflicts.length} missing=${updateResult.missing.length}`);
-    } catch (error) {
-      updateError = error instanceof Error ? error.message : String(error);
-      updateResult = null;
-      log(`DB update error: ${updateError}`);
-    }
-  }
-
   const report = {
     generatedAt: new Date().toISOString(),
     reportSource: args.report,
@@ -1032,9 +893,6 @@ const main = async () => {
     unmatched,
     selectedInvalidations,
     errors,
-    ...(args.execute
-      ? { executed: true, updated: updateResult?.updated ?? 0, conflicts: updateResult?.conflicts ?? [], missing: updateResult?.missing ?? [], updateError }
-      : { executed: false }),
   };
 
   const output = stringifyJson(report, args.pretty);

--- a/scripts/permit2-tools.ts
+++ b/scripts/permit2-tools.ts
@@ -1,6 +1,6 @@
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { encodeFunctionData, hashTypedData, parseAbiItem, recoverAddress } from "viem";
-import type { Database } from "../src/database.types.ts";
+import type { Database, Tables } from "../src/database.types.ts";
 
 export const OLD_PERMIT2_ADDRESS = "0x000000000022D473030F116dDEE9F6B43aC78BA3";
 export const NEW_PERMIT2_ADDRESS = "0xd635918A75356D133d5840eE5c9ED070302C9C60";
@@ -19,7 +19,7 @@ export const PERMIT_TRANSFER_FROM_TYPES = {
   ],
 } as const;
 
-export type PermitDbRow = Database["public"]["Tables"]["permits"]["Row"];
+export type PermitDbRow = Tables<"permits">;
 
 export type PermitDbRowWithJoins = PermitDbRow & {
   token?: { address?: string | null; network?: number | string | null } | null;
@@ -141,7 +141,6 @@ export async function fetchPermitsFromDb({
     deadline,
     signature,
     transaction,
-    invalidation,
     created,
     beneficiary_id,
     location_id,

--- a/src/database.types.ts
+++ b/src/database.types.ts
@@ -1,66 +1,14 @@
-export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
+// This type is used internally by other exports
+type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
 
 export type Database = {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "11.2.0 (c820efb)";
+  };
   public: {
     Tables: {
-      access: {
-        Row: {
-          created: string;
-          id: number;
-          labels: Json | null;
-          location_id: number | null;
-          multiplier: number;
-          multiplier_reason: string | null;
-          repository_id: number | null;
-          updated: string | null;
-          user_id: number;
-        };
-        Insert: {
-          created?: string;
-          id?: number;
-          labels?: Json | null;
-          location_id?: number | null;
-          multiplier?: number;
-          multiplier_reason?: string | null;
-          repository_id?: number | null;
-          updated?: string | null;
-          user_id: number;
-        };
-        Update: {
-          created?: string;
-          id?: number;
-          labels?: Json | null;
-          location_id?: number | null;
-          multiplier?: number;
-          multiplier_reason?: string | null;
-          repository_id?: number | null;
-          updated?: string | null;
-          user_id?: number;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "access_user_id_fkey";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "fk_access_location";
-            columns: ["location_id"];
-            isOneToOne: false;
-            referencedRelation: "issues_view";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "fk_access_location";
-            columns: ["location_id"];
-            isOneToOne: false;
-            referencedRelation: "locations";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
       credits: {
         Row: {
           amount: number;
@@ -236,51 +184,6 @@ export type Database = {
         };
         Relationships: [];
       };
-      labels: {
-        Row: {
-          authorized: boolean | null;
-          created: string;
-          id: number;
-          label_from: string | null;
-          label_to: string | null;
-          location_id: number | null;
-          updated: string | null;
-        };
-        Insert: {
-          authorized?: boolean | null;
-          created?: string;
-          id?: number;
-          label_from?: string | null;
-          label_to?: string | null;
-          location_id?: number | null;
-          updated?: string | null;
-        };
-        Update: {
-          authorized?: boolean | null;
-          created?: string;
-          id?: number;
-          label_from?: string | null;
-          label_to?: string | null;
-          location_id?: number | null;
-          updated?: string | null;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "labels_location_id_fkey";
-            columns: ["location_id"];
-            isOneToOne: false;
-            referencedRelation: "issues_view";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "labels_location_id_fkey";
-            columns: ["location_id"];
-            isOneToOne: false;
-            referencedRelation: "locations";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
       locations: {
         Row: {
           comment_id: number | null;
@@ -322,51 +225,6 @@ export type Database = {
           user_id?: number | null;
         };
         Relationships: [];
-      };
-      logs: {
-        Row: {
-          created: string;
-          id: number;
-          level: string | null;
-          location_id: number | null;
-          log: string;
-          metadata: Json | null;
-          updated: string | null;
-        };
-        Insert: {
-          created?: string;
-          id?: number;
-          level?: string | null;
-          location_id?: number | null;
-          log: string;
-          metadata?: Json | null;
-          updated?: string | null;
-        };
-        Update: {
-          created?: string;
-          id?: number;
-          level?: string | null;
-          location_id?: number | null;
-          log?: string;
-          metadata?: Json | null;
-          updated?: string | null;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "fk_logs_location";
-            columns: ["location_id"];
-            isOneToOne: false;
-            referencedRelation: "issues_view";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "fk_logs_location";
-            columns: ["location_id"];
-            isOneToOne: false;
-            referencedRelation: "locations";
-            referencedColumns: ["id"];
-          },
-        ];
       };
       partners: {
         Row: {
@@ -426,7 +284,6 @@ export type Database = {
           partner_id: number | null;
           signature: string;
           token_id: number | null;
-          invalidation: string | null;
           transaction: string | null;
           updated: string | null;
         };
@@ -441,7 +298,6 @@ export type Database = {
           partner_id?: number | null;
           signature: string;
           token_id?: number | null;
-          invalidation?: string | null;
           transaction?: string | null;
           updated?: string | null;
         };
@@ -456,7 +312,6 @@ export type Database = {
           partner_id?: number | null;
           signature?: string;
           token_id?: number | null;
-          invalidation?: string | null;
           transaction?: string | null;
           updated?: string | null;
         };
@@ -729,9 +584,7 @@ export type Database = {
         Returns: undefined;
       };
       read_secret: {
-        Args: {
-          secret_name: string;
-        };
+        Args: { secret_name: string };
         Returns: string;
       };
     };
@@ -807,21 +660,29 @@ export type Database = {
   };
 };
 
-type PublicSchema = Database[Extract<keyof Database, "public">];
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">;
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">];
 
 export type Tables<
-  PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] & PublicSchema["Views"]) | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] & Database[PublicTableNameOrOptions["schema"]]["Views"])
+  DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] & DefaultSchema["Views"]) | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
     : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] & Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
       Row: infer R;
     }
     ? R
     : never
-  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] & PublicSchema["Views"])
-    ? (PublicSchema["Tables"] & PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] & DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
         Row: infer R;
       }
       ? R
@@ -829,16 +690,22 @@ export type Tables<
     : never;
 
 export type TablesInsert<
-  PublicTableNameOrOptions extends keyof PublicSchema["Tables"] | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database } ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"] : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+  DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"] | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Insert: infer I;
     }
     ? I
     : never
-  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
         Insert: infer I;
       }
       ? I
@@ -846,16 +713,22 @@ export type TablesInsert<
     : never;
 
 export type TablesUpdate<
-  PublicTableNameOrOptions extends keyof PublicSchema["Tables"] | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database } ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"] : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+  DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"] | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Update: infer U;
     }
     ? U
     : never
-  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
         Update: infer U;
       }
       ? U
@@ -863,23 +736,32 @@ export type TablesUpdate<
     : never;
 
 export type Enums<
-  PublicEnumNameOrOptions extends keyof PublicSchema["Enums"] | { schema: keyof Database },
-  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database } ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"] : never = never,
-> = PublicEnumNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
-    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+  DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"] | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
     : never;
 
 export type CompositeTypes<
-  PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"] | { schema: keyof Database },
+  PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"] | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof Database;
+    schema: keyof DatabaseWithoutInternals;
   }
-    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
-> = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
-    ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never;
+

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ interface TokenInfoInternal {
 
 interface PartnerInfoInternal {
   wallet?: {
-    address: string;
+    address: string | null;
   };
 }
 
@@ -41,7 +41,7 @@ export interface PermitData {
   permit2Address: `0x${string}`;
 
   // Frontend-specific statuses for validation/testing
-  status?: "Valid" | "Claimed" | "Expired" | "Invalid" | "Fetching" | "Testing";
+  status?: "Valid" | "Claimed" | "Expired" | "Invalid" | "Invalidated" | "Fetching" | "Testing";
   testError?: string; // For storing error messages during claim testing
 
   // Frontend-specific statuses for actual claiming
@@ -61,4 +61,7 @@ export interface PermitData {
   // --- Fields for CowSwap Quote Estimation ---
   estimatedAmountOut?: string; // Store as string (wei) to handle large numbers
   quoteError?: string | null; // Error message if quote fetching fails for this permit's group
+
+  // Created timestamp from database
+  created_at?: string;
 }


### PR DESCRIPTION
## Summary
Closes #433

Refresh Supabase database types and tighten type safety for permit DB operations.

### Changes
- Regenerated/ported `src/database.types.ts` from the issue migration reference (`development-broken`), including helper types (`Tables`, `TablesInsert`, `TablesUpdate`, `Enums`, `CompositeTypes`) and `__InternalSupabase` metadata
- Removed unused generated tables (`access`, `labels`, `logs`) that are not used by this app
- Removed stale `permits.invalidation` column from generated types (no longer in reference schema)
- Backend `serve.ts` already uses `createClient<Database>`; left typed client intact
- Updated frontend `PermitData` (`Invalidated` status, nullable partner wallet address, `created_at`)
- Updated Permit2 scripts that still selected/wrote `permits.invalidation`
- Switched `PermitDbRow` to `Tables<"permits">`

### Schema assumption
Could not regenerate against production Supabase (no `SUPABASE_*` credentials in this environment). Types were taken from `upstream/development-broken:src/frontend/src/database.types.ts` (767 lines), as specified by the issue migration reference. Path in current tree is `src/database.types.ts` (frontend/backend split was flattened).

### Validation
- `bunx tsc --noEmit` ✅
- `bun run lint` ✅
- `bun run build` ✅
- `deno check --lock=deno.lock serve.ts scripts/permit2-audit.ts scripts/permit2-scan-invalidations.ts scripts/permit2-tools.ts` ✅

### Blockers / notes
- `/wallet` already registered for `0x7829a0A2a6Ec3c7c552b09376271f3b22a850d7B`
- `/start` rejected by UbiquityOS (“must be a core team member, or an administrator”)
- Production schema parity not verified live; please confirm `permits.invalidation` and unused tables match production before merge